### PR TITLE
Allow get superblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,16 @@ func main() {
     if err != nil {
         log.Fatal(err)
     }
-	info, _ := f.Stat()
-    filesystem, err := ext4.NewFS(io.NewSectionReader(f,0, info.Size()), nil)
+    filesize, err := f.Seek(0, io.SeekEnd)
+    if err != nil {
+        log.Fatal(err)
+    }
+    _, err = f.Seek(0, io.SeekStart)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    filesystem, err := ext4.NewFS(io.NewSectionReader(f,0, filesize), nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -346,3 +346,7 @@ func (ext4 *FileSystem) wrapError(op, path string, err error) error {
 		Err:  err,
 	}
 }
+
+func (ext4 *FileSystem) GetSuperBlock() Superblock {
+	return ext4.sb
+}


### PR DESCRIPTION
* First patch adds a function to get the superblock data.
* Second patch change the sample code to use seeking to get the file size. This works with block device too (/dev/sda)
