### PR TITLE
feat: Support for resolving symbolic links (io.ReadLinkFS)

### DIFF
--- a/ext4/const.go
+++ b/ext4/const.go
@@ -43,3 +43,15 @@ const (
 	FEATURE_INCOMPAT_INLINE_DATA    = 0x8000
 	FEATURE_INCOMPAT_ENCRYPT        = 0x10000
 )
+
+// File types (upper 4 bits of i_mode)
+const (
+	FileTypeMask        = 0xF000
+	FileTypeSocket      = 0xC000
+	FileTypeSymlink     = 0xA000
+	FileTypeRegular     = 0x8000
+	FileTypeBlockDevice = 0x6000
+	FileTypeDir         = 0x4000
+	FileTypeCharDevice  = 0x2000
+	FileTypeFifo        = 0x1000
+)

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -348,7 +348,7 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 
 		// Resolve symlinks
 		if dir.inode.IsSymlink() {
-			link, err := ext4.ReadLink(name)
+			link, err := ext4.ReadLink(dir.name)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read link: %w", err)
 			}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -17,8 +17,6 @@ var (
 	_ fs.FS        = &FileSystem{}
 	_ fs.ReadDirFS = &FileSystem{}
 	_ fs.StatFS    = &FileSystem{}
-
-	ErrOpenSymlink = xerrors.New("open symlink does not support")
 )
 
 // FileSystem is implemented io/fs interface
@@ -347,8 +345,14 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 		if !ok {
 			return nil, xerrors.Errorf("unspecified error, entry is not dir entry %+v", entry)
 		}
-		if dir.inode.Mode&0xA000 == 0xA000 {
-			return nil, ErrOpenSymlink
+
+		// Resolve symlinks
+		if dir.inode.IsSymlink() {
+			link, err := ext4.ReadLink(name)
+			if err != nil {
+				return nil, xerrors.Errorf("failed to read link: %w", err)
+			}
+			return ext4.Open(link)
 		}
 
 		fi := FileInfo{
@@ -369,6 +373,46 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 		return f, nil
 	}
 	return nil, fs.ErrNotExist
+}
+
+func (ext4 *FileSystem) ReadLink(name string) (string, error) {
+	di, err := ext4.ReadDirInfo(name)
+	if err != nil {
+		return "", xerrors.Errorf("failed to read dir info: %w", err)
+	}
+	fi, ok := di.(FileInfo)
+	if !ok {
+		return "", xerrors.Errorf("unspecified error, entry is not file info %+v", fi)
+	}
+	inode := fi.inode
+	if !inode.IsSymlink() {
+		return "", xerrors.Errorf("file is not symlink: %w", fs.ErrInvalid)
+	}
+
+	// Depending on the target size, it is stored either in the inode block or the extents
+	targetSize := inode.GetSize()
+	if !inode.UsesExtents() {
+		path := string(inode.BlockOrExtents[:targetSize])
+		return filepath.Clean(path), nil
+	}
+
+	// For symlinks stored in extents, read the target using the File abstraction
+	f, err := ext4.file(fi, name)
+	if err != nil {
+		return "", xerrors.Errorf("failed to create file reader: %w", err)
+	}
+	defer f.Close()
+
+	target, err := io.ReadAll(f)
+	if err != nil {
+		return "", xerrors.Errorf("failed to read symlink target: %w", err)
+	}
+
+	return filepath.Clean(string(target)), nil
+}
+
+func (ext4 *FileSystem) Lstat(name string) (fs.FileInfo, error) {
+	return ext4.Stat(name)
 }
 
 func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, error) {

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -81,19 +81,19 @@ type BlockAddressing struct {
 }
 
 func (i Inode) IsDir() bool {
-	return i.Mode&0x4000 != 0 && i.Mode&0x8000 == 0
+	return (i.Mode & FileTypeMask) == FileTypeDir
 }
 
 func (i Inode) IsRegular() bool {
-	return i.Mode&0x8000 != 0 && i.Mode&0x4000 == 0
+	return (i.Mode & FileTypeMask) == FileTypeRegular
 }
 
 func (i Inode) IsSocket() bool {
-	return i.Mode&0xC000 != 0
+	return (i.Mode & FileTypeMask) == FileTypeSocket
 }
 
 func (i Inode) IsSymlink() bool {
-	return i.Mode&0xA000 != 0
+	return (i.Mode & FileTypeMask) == FileTypeSymlink
 }
 
 // UsesExtents


### PR DESCRIPTION
This PR adds `ReadLink` and `Lstat` methods to `ext4.(*FileSystem)` in order to support go1.25 `ReadLinkFS`: https://pkg.go.dev/io/fs@master#ReadLinkFS

By default, this patch will automatically resolve symbolic links when encountered in an `Open()` call.

Additionally this fixes the inode mode helper methods which were incorrectly interpreting inode mode bits.