### PR TITLE
Fix ext4/ext3/ext2 spec compliance, add HTree support and comprehensive validation

### DIFF
--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -128,6 +128,10 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 		return nil, xerrors.Errorf("failed to parse extent header: %w", err)
 	}
 
+	if extentHeader.Magic != 0xF30A {
+		return nil, xerrors.Errorf("invalid extent header magic: %#x", extentHeader.Magic)
+	}
+
 	if extentHeader.Depth > 5 {
 		return nil, xerrors.Errorf("extent tree depth %d exceeds maximum of 5", extentHeader.Depth)
 	}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -41,7 +41,7 @@ func (ext4 *FileSystem) Extents(inode *Inode) ([]Extent, error) {
 }
 
 func (sb Superblock) getGroupDescriptor(r io.SectionReader) ([]GroupDescriptor, error) {
-	_, err := r.Seek(sb.GetBlockSize(), 0)
+	_, err := r.Seek(int64(sb.FirstDataBlock+1)*sb.GetBlockSize(), 0)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to seek Group Descriptor offset: %w", err)
 	}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -185,7 +185,7 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent, expectedDepth int) (
 }
 
 func (e *Extent) offset() int64 {
-	return int64(e.StartHi)<<32 + int64(e.StartLo)
+	return int64(e.StartHi)<<32 | int64(e.StartLo)
 }
 
 func divWithRoundUp(a int, b int) int {

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -82,7 +82,7 @@ func (sb Superblock) getGroupDescriptor(r io.SectionReader) ([]GroupDescriptor, 
 func (ext4 *FileSystem) getInode(inodeAddress int64) (*Inode, error) {
 	c, ok := ext4.cache.Get(inodeCacheKey(inodeAddress))
 	if ok {
-		i := c.(Inode)
+		i, ok := c.(Inode)
 		if ok {
 			return &i, nil
 		}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -20,6 +20,11 @@ Ext4 Block Layout
 +-----------------+------------------+-------------------+---------------------+-------------------+--------------+-------------+------------------+
 */
 
+const (
+	// extentDepthRoot indicates no parent depth to validate against.
+	extentDepthRoot = -1
+)
+
 var (
 	ErrInodeNotFound = xerrors.New("inode not found")
 )
@@ -33,7 +38,7 @@ func Check(r io.Reader) bool {
 }
 
 func (ext4 *FileSystem) Extents(inode *Inode) ([]Extent, error) {
-	extents, err := ext4.extents(inode.BlockOrExtents[:], nil)
+	extents, err := ext4.extents(inode.BlockOrExtents[:], nil, extentDepthRoot)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get extents: %w", err)
 	}
@@ -120,7 +125,7 @@ func (ext4 *FileSystem) getInode(inodeAddress int64) (*Inode, error) {
 	return &inode, nil
 }
 
-func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
+func (ext4 *FileSystem) extents(b []byte, extents []Extent, expectedDepth int) ([]Extent, error) {
 	extentReader := bytes.NewReader(b)
 	extentHeader := &ExtentHeader{}
 	err := binary.Read(extentReader, binary.LittleEndian, extentHeader)
@@ -134,6 +139,10 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 
 	if extentHeader.Depth > 5 {
 		return nil, xerrors.Errorf("extent tree depth %d exceeds maximum of 5", extentHeader.Depth)
+	}
+
+	if expectedDepth >= 0 && int(extentHeader.Depth) != expectedDepth {
+		return nil, xerrors.Errorf("extent tree depth %d does not match expected %d", extentHeader.Depth, expectedDepth)
 	}
 
 	if extentHeader.Entries > extentHeader.Max {
@@ -163,7 +172,7 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 				return nil, xerrors.Errorf("failed to read leaf node extent: %w", err)
 			}
 
-			extents, err = ext4.extents(b, extents)
+			extents, err = ext4.extents(b, extents, int(extentHeader.Depth)-1)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to get extents: %w", err)
 			}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -145,7 +145,8 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 				return nil, xerrors.Errorf("failed to read internal extent: %w", err)
 			}
 			b := make([]byte, ext4.sb.GetBlockSize())
-			_, err = ext4.r.ReadAt(b, int64(extent.LeafHigh)<<32+int64(extent.LeafLow)*ext4.sb.GetBlockSize())
+			physBlock := int64(extent.LeafHigh)<<32 | int64(extent.LeafLow)
+			_, err = ext4.r.ReadAt(b, physBlock*ext4.sb.GetBlockSize())
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read leaf node extent: %w", err)
 			}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -128,6 +128,10 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 		return nil, xerrors.Errorf("failed to parse extent header: %w", err)
 	}
 
+	if extentHeader.Depth > 5 {
+		return nil, xerrors.Errorf("extent tree depth %d exceeds maximum of 5", extentHeader.Depth)
+	}
+
 	if extentHeader.Depth == 0 {
 		for entry := uint16(0); entry < extentHeader.Entries; entry++ {
 			var extent Extent

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -97,16 +97,18 @@ func (ext4 *FileSystem) getInode(inodeAddress int64) (*Inode, error) {
 	index := (inodeAddress - 1) % int64(ext4.sb.InodePerGroup)
 	physicalOffset := bgd.GetInodeTableLoc(ext4.sb.FeatureInCompat64bit())*ext4.sb.GetBlockSize() + index*int64(ext4.sb.InodeSize)
 
-	// offset need to 512*N offset
-	inodeOffset := physicalOffset % SectorSize
-	seekOffset := physicalOffset - (physicalOffset % SectorSize)
-	buf := make([]byte, SectorSize)
-	_, err := ext4.r.ReadAt(buf, seekOffset)
+	inodeStructSize := int64(binary.Size(Inode{}))
+	buf := make([]byte, inodeStructSize)
+
+	// Read only the on-disk inode size; for ext2/ext3 (InodeSize=128)
+	// the remaining bytes stay zero, giving safe defaults for extended fields.
+	readSize := inodeStructSize
+	if int64(ext4.sb.InodeSize) < readSize {
+		readSize = int64(ext4.sb.InodeSize)
+	}
+	_, err := ext4.r.ReadAt(buf[:readSize], physicalOffset)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read inode: %w", err)
-	}
-	if inodeOffset != 0 && int64(len(buf)) > inodeOffset {
-		buf = buf[inodeOffset:]
 	}
 
 	inode := Inode{}

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -136,6 +136,10 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 		return nil, xerrors.Errorf("extent tree depth %d exceeds maximum of 5", extentHeader.Depth)
 	}
 
+	if extentHeader.Entries > extentHeader.Max {
+		return nil, xerrors.Errorf("extent header entries (%d) exceeds max (%d)", extentHeader.Entries, extentHeader.Max)
+	}
+
 	if extentHeader.Depth == 0 {
 		for entry := uint16(0); entry < extentHeader.Entries; entry++ {
 			var extent Extent

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -42,6 +42,9 @@ func (ext4 *FileSystem) Extents(inode *Inode) ([]Extent, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get extents: %w", err)
 	}
+	sort.Slice(extents, func(i, j int) bool {
+		return extents[i].Block < extents[j].Block
+	})
 	return extents, nil
 }
 
@@ -178,9 +181,6 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent, expectedDepth int) (
 			}
 		}
 	}
-	sort.Slice(extents, func(i, j int) bool {
-		return extents[i].Block < extents[j].Block
-	})
 	return extents, nil
 }
 

--- a/ext4/ext4.go
+++ b/ext4/ext4.go
@@ -142,7 +142,7 @@ func (ext4 *FileSystem) extents(b []byte, extents []Extent) ([]Extent, error) {
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read internal extent: %w", err)
 			}
-			b := make([]byte, SectorSize)
+			b := make([]byte, ext4.sb.GetBlockSize())
 			_, err = ext4.r.ReadAt(b, int64(extent.LeafHigh)<<32+int64(extent.LeafLow)*ext4.sb.GetBlockSize())
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read leaf node extent: %w", err)

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -82,7 +82,7 @@ func TestExtents_InternalNodeLeafHighAddress(t *testing.T) {
 	const leafLow = uint32(2)
 	// The leaf node should be at physical block (1<<32 | 2) = 0x100000002
 	expectedBlock := int64(leafHigh)<<32 | int64(leafLow) // 4294967298
-	expectedOffset := expectedBlock * blockSize            // 17592186044416
+	expectedOffset := expectedBlock * blockSize           // 17592186044416
 
 	// We need an image large enough; use a SectionReader that allows reads
 	// at any offset by backing with a custom ReaderAt.
@@ -123,8 +123,8 @@ func TestExtents_InternalNodeLeafHighAddress(t *testing.T) {
 		Depth:   1,
 	})
 	binary.Write(rootBuf, binary.LittleEndian, ExtentInternal{
-		Block:   0,
-		LeafLow: leafLow,
+		Block:    0,
+		LeafLow:  leafLow,
 		LeafHigh: leafHigh,
 	})
 

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -72,6 +72,26 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 	}
 }
 
+// TestExtents_DepthExceedsMax verifies that extents() rejects an extent tree
+// with depth > 5, which is the maximum defined by the ext4 specification.
+func TestExtents_DepthExceedsMax(t *testing.T) {
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 0,
+		Max:     4,
+		Depth:   6,
+	})
+
+	fs := &FileSystem{
+		sb: Superblock{LogBlockSize: 2},
+	}
+	_, err := fs.extents(rootBuf.Bytes(), nil)
+	if err == nil {
+		t.Fatal("extents() should return error for depth > 5")
+	}
+}
+
 // TestExtents_InternalNodeLeafHighAddress verifies that extents() correctly
 // combines LeafHigh and LeafLow to compute the physical block address for
 // internal extent nodes. Before the fix, LeafHigh<<32 was added to

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -72,6 +72,93 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 	}
 }
 
+// TestExtents_InternalNodeLeafHighAddress verifies that extents() correctly
+// combines LeafHigh and LeafLow to compute the physical block address for
+// internal extent nodes. Before the fix, LeafHigh<<32 was added to
+// LeafLow*blockSize due to operator precedence, producing a wrong offset.
+func TestExtents_InternalNodeLeafHighAddress(t *testing.T) {
+	const blockSize = 4096
+	const leafHigh = uint16(1)
+	const leafLow = uint32(2)
+	// The leaf node should be at physical block (1<<32 | 2) = 0x100000002
+	expectedBlock := int64(leafHigh)<<32 | int64(leafLow) // 4294967298
+	expectedOffset := expectedBlock * blockSize            // 17592186044416
+
+	// We need an image large enough; use a SectionReader that allows reads
+	// at any offset by backing with a custom ReaderAt.
+	leafBuf := make([]byte, blockSize)
+	leafWriter := bytes.NewBuffer(leafBuf[:0])
+	binary.Write(leafWriter, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 1,
+		Max:     340,
+		Depth:   0,
+	})
+	binary.Write(leafWriter, binary.LittleEndian, Extent{
+		Block:   0,
+		Len:     1,
+		StartHi: 0,
+		StartLo: 999,
+	})
+	copy(leafBuf, leafWriter.Bytes())
+
+	// sparseReader returns leafBuf at the expected offset, zeros elsewhere.
+	sr := &sparseBlockReader{
+		targetOffset: expectedOffset,
+		data:         leafBuf,
+	}
+	r := io.NewSectionReader(sr, 0, expectedOffset+int64(blockSize))
+	fs := &FileSystem{
+		r: r,
+		sb: Superblock{
+			LogBlockSize: 2, // 4096
+		},
+	}
+
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 1,
+		Max:     4,
+		Depth:   1,
+	})
+	binary.Write(rootBuf, binary.LittleEndian, ExtentInternal{
+		Block:   0,
+		LeafLow: leafLow,
+		LeafHigh: leafHigh,
+	})
+
+	extents, err := fs.extents(rootBuf.Bytes(), nil)
+	if err != nil {
+		t.Fatalf("extents() error: %v", err)
+	}
+	if len(extents) != 1 {
+		t.Errorf("got %d extents, want 1", len(extents))
+	}
+}
+
+// sparseBlockReader is a ReaderAt that returns data at a specific offset
+// and zeros everywhere else.
+type sparseBlockReader struct {
+	targetOffset int64
+	data         []byte
+}
+
+func (s *sparseBlockReader) ReadAt(p []byte, off int64) (int, error) {
+	end := off + int64(len(p))
+	targetEnd := s.targetOffset + int64(len(s.data))
+
+	if off >= s.targetOffset && end <= targetEnd {
+		copy(p, s.data[off-s.targetOffset:])
+		return len(p), nil
+	}
+	// Return zeros for any other offset
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
 // TestGetInode_SmallInodeSize verifies that getInode() correctly reads
 // inodes when InodeSize is smaller than the Go Inode struct (256 bytes).
 // With InodeSize=128 (ext2/ext3), every 4th inode in a sector would

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -1,0 +1,73 @@
+package ext4
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+// TestExtents_InternalNodeUsesFullBlockSize verifies that extents() reads
+// the full block size (not SectorSize) when following internal extent nodes.
+// With a 4096-byte block, a leaf node can hold up to 340 extents, but if
+// only 512 bytes were read, only 41 would be visible.
+func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
+	const blockSize = 4096
+	const leafBlock = 1 // leaf node at block 1
+
+	// Number of leaf extents: 50 exceeds SectorSize (512B) capacity of 41.
+	const numExtents = 50
+
+	// Build the leaf block: ExtentHeader (depth=0) + numExtents Extent entries
+	leafBuf := make([]byte, blockSize)
+	leafWriter := bytes.NewBuffer(leafBuf[:0])
+	binary.Write(leafWriter, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: numExtents,
+		Max:     340,
+		Depth:   0,
+	})
+	for i := uint32(0); i < numExtents; i++ {
+		binary.Write(leafWriter, binary.LittleEndian, Extent{
+			Block:   i * 10,
+			Len:     1,
+			StartHi: 0,
+			StartLo: 100 + i,
+		})
+	}
+	copy(leafBuf, leafWriter.Bytes())
+
+	// Build the image: block 0 is unused, block 1 is the leaf node
+	imageSize := blockSize * 2
+	image := make([]byte, imageSize)
+	copy(image[blockSize:], leafBuf)
+
+	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(imageSize))
+	fs := &FileSystem{
+		r: r,
+		sb: Superblock{
+			LogBlockSize: 2, // 1024 << 2 = 4096
+		},
+	}
+
+	// Build root extent data: header (depth=1, 1 entry) + 1 internal entry
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 1,
+		Max:     4,
+		Depth:   1,
+	})
+	binary.Write(rootBuf, binary.LittleEndian, ExtentInternal{
+		Block:   0,
+		LeafLow: leafBlock,
+	})
+
+	extents, err := fs.extents(rootBuf.Bytes(), nil)
+	if err != nil {
+		t.Fatalf("extents() error: %v", err)
+	}
+	if len(extents) != numExtents {
+		t.Errorf("got %d extents, want %d (buffer may be too small)", len(extents), numExtents)
+	}
+}

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -72,6 +72,26 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 	}
 }
 
+// TestExtents_InvalidMagic verifies that extents() rejects an extent header
+// with an invalid magic number.
+func TestExtents_InvalidMagic(t *testing.T) {
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0x0000,
+		Entries: 0,
+		Max:     4,
+		Depth:   0,
+	})
+
+	fs := &FileSystem{
+		sb: Superblock{LogBlockSize: 2},
+	}
+	_, err := fs.extents(rootBuf.Bytes(), nil)
+	if err == nil {
+		t.Fatal("extents() should return error for invalid magic")
+	}
+}
+
 // TestExtents_DepthExceedsMax verifies that extents() rejects an extent tree
 // with depth > 5, which is the maximum defined by the ext4 specification.
 func TestExtents_DepthExceedsMax(t *testing.T) {

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -71,3 +71,127 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 		t.Errorf("got %d extents, want %d (buffer may be too small)", len(extents), numExtents)
 	}
 }
+
+// TestGetInode_SmallInodeSize verifies that getInode() correctly reads
+// inodes when InodeSize is smaller than the Go Inode struct (256 bytes).
+// With InodeSize=128 (ext2/ext3), every 4th inode in a sector would
+// previously fail with EOF because only 512 bytes were read.
+func TestGetInode_SmallInodeSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		inodeSize uint16
+		numInodes int // number of inodes to test within one group
+	}{
+		{
+			name:      "ext2/ext3: InodeSize=128, 4 inodes per sector",
+			inodeSize: 128,
+			numInodes: 8, // 2 sectors worth
+		},
+		{
+			name:      "ext4: InodeSize=256, 2 inodes per sector",
+			inodeSize: 256,
+			numInodes: 4, // 2 sectors worth
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const blockSize int64 = 4096
+			const inodeTableBlock = 1 // inode table starts at block 1
+
+			// Build an image with inode table data.
+			// Each inode on disk is InodeSize bytes. We place a marker in the
+			// Mode field (offset 0) of each inode.
+			imageSize := blockSize * 2 // block 0 unused, block 1 = inode table
+			image := make([]byte, imageSize)
+
+			for i := 0; i < tt.numInodes; i++ {
+				offset := int(blockSize)*inodeTableBlock + i*int(tt.inodeSize)
+				marker := uint16(0x8000 + i) // distinct Mode value per inode
+				binary.LittleEndian.PutUint16(image[offset:offset+2], marker)
+			}
+
+			r := io.NewSectionReader(bytes.NewReader(image), 0, int64(imageSize))
+
+			gd := GroupDescriptor{}
+			gd.InodeTableLo = inodeTableBlock
+
+			fs := &FileSystem{
+				r: r,
+				sb: Superblock{
+					LogBlockSize:  2, // 4096
+					InodeSize:     tt.inodeSize,
+					InodePerGroup: uint32(tt.numInodes),
+				},
+				gds:   []GroupDescriptor{gd},
+				cache: &mockCache[string, any]{},
+			}
+
+			for i := 0; i < tt.numInodes; i++ {
+				inodeAddr := int64(i + 1) // inode numbers are 1-based
+				inode, err := fs.getInode(inodeAddr)
+				if err != nil {
+					t.Fatalf("getInode(%d) error: %v (InodeSize=%d, offset within sector=%d)",
+						inodeAddr, err, tt.inodeSize, (i*int(tt.inodeSize))%SectorSize)
+				}
+				wantMode := uint16(0x8000 + i)
+				if inode.Mode != wantMode {
+					t.Errorf("inode %d: Mode=%#x, want %#x", inodeAddr, inode.Mode, wantMode)
+				}
+			}
+		})
+	}
+}
+
+// TestGetInode_SmallInodeSizeExtendedFieldsZero verifies that when
+// InodeSize < Go struct size, extended fields are zero-initialized.
+func TestGetInode_SmallInodeSizeExtendedFieldsZero(t *testing.T) {
+	const blockSize int64 = 4096
+	const inodeTableBlock = 1
+	const inodeSize = 128
+
+	imageSize := blockSize * 2
+	image := make([]byte, imageSize)
+
+	// Write a valid inode at index 0 with Mode = regular file
+	offset := int(blockSize) * inodeTableBlock
+	binary.LittleEndian.PutUint16(image[offset:offset+2], 0x8180) // Mode: regular + 0o600
+
+	// Write garbage at byte 128+ (this is the NEXT inode's space, not ours)
+	for i := offset + inodeSize; i < offset+256 && i < len(image); i++ {
+		image[i] = 0xFF
+	}
+
+	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(imageSize))
+	gd := GroupDescriptor{}
+	gd.InodeTableLo = inodeTableBlock
+
+	fs := &FileSystem{
+		r: r,
+		sb: Superblock{
+			LogBlockSize:  2,
+			InodeSize:     inodeSize,
+			InodePerGroup: 16,
+		},
+		gds:   []GroupDescriptor{gd},
+		cache: &mockCache[string, any]{},
+	}
+
+	inode, err := fs.getInode(1)
+	if err != nil {
+		t.Fatalf("getInode(1) error: %v", err)
+	}
+
+	// Mode should be read correctly
+	if inode.Mode != 0x8180 {
+		t.Errorf("Mode = %#x, want %#x", inode.Mode, 0x8180)
+	}
+
+	// Extended fields (beyond 128 bytes) should be zero, NOT 0xFF garbage
+	if inode.ExtraIsize != 0 {
+		t.Errorf("ExtraIsize = %d, want 0 (should not read adjacent inode data)", inode.ExtraIsize)
+	}
+	if inode.CtimeExtra != 0 {
+		t.Errorf("CtimeExtra = %#x, want 0", inode.CtimeExtra)
+	}
+}

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -72,6 +72,26 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 	}
 }
 
+// TestExtents_EntriesExceedsMax verifies that extents() rejects an extent
+// header where Entries > Max.
+func TestExtents_EntriesExceedsMax(t *testing.T) {
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 10,
+		Max:     4,
+		Depth:   0,
+	})
+
+	fs := &FileSystem{
+		sb: Superblock{LogBlockSize: 2},
+	}
+	_, err := fs.extents(rootBuf.Bytes(), nil)
+	if err == nil {
+		t.Fatal("extents() should return error when Entries > Max")
+	}
+}
+
 // TestExtents_InvalidMagic verifies that extents() rejects an extent header
 // with an invalid magic number.
 func TestExtents_InvalidMagic(t *testing.T) {

--- a/ext4/ext4_test.go
+++ b/ext4/ext4_test.go
@@ -63,7 +63,7 @@ func TestExtents_InternalNodeUsesFullBlockSize(t *testing.T) {
 		LeafLow: leafBlock,
 	})
 
-	extents, err := fs.extents(rootBuf.Bytes(), nil)
+	extents, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
 	if err != nil {
 		t.Fatalf("extents() error: %v", err)
 	}
@@ -86,9 +86,52 @@ func TestExtents_EntriesExceedsMax(t *testing.T) {
 	fs := &FileSystem{
 		sb: Superblock{LogBlockSize: 2},
 	}
-	_, err := fs.extents(rootBuf.Bytes(), nil)
+	_, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
 	if err == nil {
 		t.Fatal("extents() should return error when Entries > Max")
+	}
+}
+
+// TestExtents_DepthMismatch verifies that extents() rejects a child node
+// whose depth does not match the expected value (parent depth - 1).
+func TestExtents_DepthMismatch(t *testing.T) {
+	const blockSize = 4096
+
+	// Build a child node with depth=1 (should be 0 if parent is depth=1)
+	childBuf := make([]byte, blockSize)
+	childWriter := bytes.NewBuffer(childBuf[:0])
+	binary.Write(childWriter, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 0,
+		Max:     340,
+		Depth:   1, // wrong: parent is depth=1, so child should be 0
+	})
+	copy(childBuf, childWriter.Bytes())
+
+	image := make([]byte, blockSize*2)
+	copy(image[blockSize:], childBuf)
+
+	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	fs := &FileSystem{
+		r:  r,
+		sb: Superblock{LogBlockSize: 2},
+	}
+
+	rootBuf := &bytes.Buffer{}
+	binary.Write(rootBuf, binary.LittleEndian, ExtentHeader{
+		Magic:   0xF30A,
+		Entries: 1,
+		Max:     4,
+		Depth:   1,
+	})
+	binary.Write(rootBuf, binary.LittleEndian, ExtentInternal{
+		Block:   0,
+		LeafLow: 1, // points to block 1
+	})
+
+	_, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
+	if err == nil {
+		t.Fatal("extents() should return error when child depth does not match expected")
 	}
 }
 
@@ -106,7 +149,7 @@ func TestExtents_InvalidMagic(t *testing.T) {
 	fs := &FileSystem{
 		sb: Superblock{LogBlockSize: 2},
 	}
-	_, err := fs.extents(rootBuf.Bytes(), nil)
+	_, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
 	if err == nil {
 		t.Fatal("extents() should return error for invalid magic")
 	}
@@ -126,7 +169,7 @@ func TestExtents_DepthExceedsMax(t *testing.T) {
 	fs := &FileSystem{
 		sb: Superblock{LogBlockSize: 2},
 	}
-	_, err := fs.extents(rootBuf.Bytes(), nil)
+	_, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
 	if err == nil {
 		t.Fatal("extents() should return error for depth > 5")
 	}
@@ -188,7 +231,7 @@ func TestExtents_InternalNodeLeafHighAddress(t *testing.T) {
 		LeafHigh: leafHigh,
 	})
 
-	extents, err := fs.extents(rootBuf.Bytes(), nil)
+	extents, err := fs.extents(rootBuf.Bytes(), nil, extentDepthRoot)
 	if err != nil {
 		t.Fatalf("extents() error: %v", err)
 	}

--- a/ext4/file.go
+++ b/ext4/file.go
@@ -94,7 +94,7 @@ func (fi FileInfo) Mode() fs.FileMode {
 	case 0x4000:
 		mode |= fs.ModeDir
 	case 0x2000:
-		mode |= fs.ModeCharDevice
+		mode |= fs.ModeCharDevice | fs.ModeDevice
 	case 0x1000:
 		mode |= fs.ModeNamedPipe
 	default:

--- a/ext4/file.go
+++ b/ext4/file.go
@@ -34,8 +34,6 @@ type FileInfo struct {
 	name  string
 	inode *Inode
 	ino   int64
-
-	mode fs.FileMode
 }
 
 // Type dirEntry is implemented io/fs DirEntry interface
@@ -71,7 +69,39 @@ func (fi FileInfo) Size() int64 {
 }
 
 func (fi FileInfo) Mode() fs.FileMode {
-	return fi.mode
+	m := fi.inode.Mode
+	mode := fs.FileMode(m & 0o777)
+
+	if m&0o1000 != 0 {
+		mode |= fs.ModeSticky
+	}
+	if m&0o2000 != 0 {
+		mode |= fs.ModeSetgid
+	}
+	if m&0o4000 != 0 {
+		mode |= fs.ModeSetuid
+	}
+
+	switch m & 0xF000 {
+	case 0xC000:
+		mode |= fs.ModeSocket
+	case 0xA000:
+		mode |= fs.ModeSymlink
+	case 0x8000:
+		// regular file
+	case 0x6000:
+		mode |= fs.ModeDevice
+	case 0x4000:
+		mode |= fs.ModeDir
+	case 0x2000:
+		mode |= fs.ModeCharDevice
+	case 0x1000:
+		mode |= fs.ModeNamedPipe
+	default:
+		mode |= fs.ModeIrregular
+	}
+
+	return mode
 }
 
 func (fi FileInfo) ModTime() time.Time {

--- a/ext4/file.go
+++ b/ext4/file.go
@@ -82,20 +82,20 @@ func (fi FileInfo) Mode() fs.FileMode {
 		mode |= fs.ModeSetuid
 	}
 
-	switch m & 0xF000 {
-	case 0xC000:
+	switch m & FileTypeMask {
+	case FileTypeSocket:
 		mode |= fs.ModeSocket
-	case 0xA000:
+	case FileTypeSymlink:
 		mode |= fs.ModeSymlink
-	case 0x8000:
+	case FileTypeRegular:
 		// regular file
-	case 0x6000:
+	case FileTypeBlockDevice:
 		mode |= fs.ModeDevice
-	case 0x4000:
+	case FileTypeDir:
 		mode |= fs.ModeDir
-	case 0x2000:
+	case FileTypeCharDevice:
 		mode |= fs.ModeCharDevice | fs.ModeDevice
-	case 0x1000:
+	case FileTypeFifo:
 		mode |= fs.ModeNamedPipe
 	default:
 		mode |= fs.ModeIrregular

--- a/ext4/file.go
+++ b/ext4/file.go
@@ -106,13 +106,12 @@ func (f *File) Read(p []byte) (n int, err error) {
 
 	offset, ok := f.table[f.currentBlock]
 	if !ok {
-		// blockSize: 512
-		// size: 2000
-		// 2000 - 512 * 3 = 464 < 512
-		if f.Size()-f.blockSize*f.currentBlock < f.blockSize {
-			f.buffer.Write(make([]byte, f.Size()-f.blockSize*f.currentBlock))
+		remaining := f.Size() - f.blockSize*f.currentBlock
+		if remaining < f.blockSize {
+			f.buffer.Write(make([]byte, remaining))
+		} else {
+			f.buffer.Write(make([]byte, f.blockSize))
 		}
-		f.buffer.Write(make([]byte, f.blockSize))
 	} else {
 		_, err := f.fs.r.Seek(offset, io.SeekStart)
 		if err != nil {

--- a/ext4/file.go
+++ b/ext4/file.go
@@ -88,7 +88,6 @@ func (fi FileInfo) Mode() fs.FileMode {
 	case FileTypeSymlink:
 		mode |= fs.ModeSymlink
 	case FileTypeRegular:
-		// regular file
 	case FileTypeBlockDevice:
 		mode |= fs.ModeDevice
 	case FileTypeDir:

--- a/ext4/file_test.go
+++ b/ext4/file_test.go
@@ -166,7 +166,7 @@ func TestFileInfoMode(t *testing.T) {
 		{"symlink 0777", 0xA1FF, fs.ModeSymlink, 0o777},
 		{"socket 0755", 0xC1ED, fs.ModeSocket, 0o755},
 		{"fifo 0644", 0x11A4, fs.ModeNamedPipe, 0o644},
-		{"char device 0666", 0x21B6, fs.ModeCharDevice, 0o666},
+		{"char device 0666", 0x21B6, fs.ModeCharDevice | fs.ModeDevice, 0o666},
 		{"block device 0660", 0x61B0, fs.ModeDevice, 0o660},
 		{"setuid", 0x89A4, 0, 0o644 | fs.ModeSetuid},
 		{"setgid", 0x85A4, 0, 0o644 | fs.ModeSetgid},

--- a/ext4/file_test.go
+++ b/ext4/file_test.go
@@ -2,6 +2,7 @@ package ext4
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"testing"
 )
@@ -148,6 +149,82 @@ func TestFileRead_AllSparse(t *testing.T) {
 	for i, b := range data {
 		if b != 0 {
 			t.Fatalf("byte %d: got %#x, want 0", i, b)
+		}
+	}
+}
+
+// TestFileRead_UninitializedExtentReadsZeros verifies that file() skips
+// uninitialized extents, and Read() returns zeros for those blocks via the
+// sparse path.
+func TestFileRead_UninitializedExtentReadsZeros(t *testing.T) {
+	const blockSize = 4096
+	// 4 blocks total: block 0-1 initialized, block 2-3 uninitialized
+	const fileSize = blockSize * 4
+
+	// Build image: 4 blocks of disk data.
+	// Blocks at physical position 0-1 contain 0xAA (will be mapped to logical 0-1).
+	// Blocks at physical position 2-3 contain 0xBB (uninitialized extent points here,
+	// but these should NOT be read).
+	image := make([]byte, blockSize*4)
+	for i := 0; i < blockSize*2; i++ {
+		image[i] = 0xAA
+	}
+	for i := blockSize * 2; i < blockSize*4; i++ {
+		image[i] = 0xBB
+	}
+
+	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+
+	// Build inode with extent tree in BlockOrExtents:
+	// ExtentHeader (depth=0, 2 entries) + 2 Extents
+	var extData [60]byte
+	buf := bytes.NewBuffer(extData[:0])
+	binary.Write(buf, binary.LittleEndian, ExtentHeader{
+		Magic: 0xF30A, Entries: 2, Max: 4, Depth: 0,
+	})
+	// Extent 1: blocks 0-1, initialized, physical block 0
+	binary.Write(buf, binary.LittleEndian, Extent{
+		Block: 0, Len: 2, StartHi: 0, StartLo: 0,
+	})
+	// Extent 2: blocks 2-3, uninitialized (bit 15 set), physical block 2
+	binary.Write(buf, binary.LittleEndian, Extent{
+		Block: 2, Len: 0x8002, StartHi: 0, StartLo: 2,
+	})
+	copy(extData[:], buf.Bytes())
+
+	inode := &Inode{
+		SizeLo: fileSize,
+		Flags:  EXTENTS_FL,
+	}
+	copy(inode.BlockOrExtents[:], extData[:])
+
+	fs := &FileSystem{
+		r:  r,
+		sb: Superblock{LogBlockSize: 2}, // 4096
+	}
+
+	fi := FileInfo{name: "test", inode: inode}
+	f, err := fs.file(fi, "test")
+	if err != nil {
+		t.Fatalf("file() error: %v", err)
+	}
+
+	data := readAll(t, f)
+	if int64(len(data)) != fileSize {
+		t.Fatalf("read %d bytes, want %d", len(data), fileSize)
+	}
+
+	// Blocks 0-1: should be 0xAA (initialized extent)
+	for i := 0; i < blockSize*2; i++ {
+		if data[i] != 0xAA {
+			t.Fatalf("byte %d (initialized): got %#x, want 0xAA", i, data[i])
+		}
+	}
+
+	// Blocks 2-3: should be 0x00 (uninitialized extent → zeros, NOT 0xBB)
+	for i := blockSize * 2; i < fileSize; i++ {
+		if data[i] != 0 {
+			t.Fatalf("byte %d (uninitialized): got %#x, want 0x00", i, data[i])
 		}
 	}
 }

--- a/ext4/file_test.go
+++ b/ext4/file_test.go
@@ -2,7 +2,6 @@ package ext4
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 	"testing"
 )
@@ -12,13 +11,7 @@ import (
 func newTestFile(image []byte, blockSize int64, fileSize int64, table dataTable) *File {
 	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
 	fs := &FileSystem{r: r}
-	inode := &Inode{}
-	binary.LittleEndian.PutUint32(
-		(*[4]byte)(inode.BlockOrExtents[40:44])[:],
-		uint32(fileSize),
-	)
-	// Set SizeLo directly
-	inode.SizeLo = uint32(fileSize)
+	inode := &Inode{SizeLo: uint32(fileSize)}
 
 	return &File{
 		FileInfo: FileInfo{

--- a/ext4/file_test.go
+++ b/ext4/file_test.go
@@ -1,0 +1,160 @@
+package ext4
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+// newTestFile creates a File with the given parameters for testing Read().
+// The dataTable maps logical block numbers to byte offsets in the image.
+func newTestFile(image []byte, blockSize int64, fileSize int64, table dataTable) *File {
+	r := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	fs := &FileSystem{r: r}
+	inode := &Inode{}
+	binary.LittleEndian.PutUint32(
+		(*[4]byte)(inode.BlockOrExtents[40:44])[:],
+		uint32(fileSize),
+	)
+	// Set SizeLo directly
+	inode.SizeLo = uint32(fileSize)
+
+	return &File{
+		FileInfo: FileInfo{
+			name:  "test",
+			inode: inode,
+		},
+		fs:           fs,
+		currentBlock: -1,
+		buffer:       bytes.NewBuffer(nil),
+		blockSize:    blockSize,
+		table:        table,
+		size:         fileSize,
+	}
+}
+
+func readAll(t *testing.T, f *File) []byte {
+	t.Helper()
+	var result []byte
+	buf := make([]byte, 256)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			result = append(result, buf[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+	}
+	return result
+}
+
+func TestFileRead_SparseLastBlock(t *testing.T) {
+	// File with blockSize=512, size=2000 (4 blocks: 3 full + 1 partial of 464 bytes).
+	// Block 0-2 have data, block 3 is sparse (not in table).
+	const blockSize = 512
+	const fileSize = 2000
+
+	// Build image with 3 blocks of known data
+	image := make([]byte, blockSize*3)
+	for i := 0; i < 3; i++ {
+		for j := 0; j < blockSize; j++ {
+			image[i*blockSize+j] = byte(i + 1) // block 0: 0x01, block 1: 0x02, block 2: 0x03
+		}
+	}
+
+	table := dataTable{
+		0: 0,
+		1: blockSize,
+		2: blockSize * 2,
+		// block 3 is sparse (missing from table)
+	}
+
+	f := newTestFile(image, blockSize, fileSize, table)
+	data := readAll(t, f)
+
+	if int64(len(data)) != fileSize {
+		t.Fatalf("read %d bytes, want %d", len(data), fileSize)
+	}
+
+	// Verify first 3 blocks have correct data
+	for i := 0; i < 3; i++ {
+		for j := 0; j < blockSize; j++ {
+			if data[i*blockSize+j] != byte(i+1) {
+				t.Fatalf("block %d byte %d: got %#x, want %#x", i, j, data[i*blockSize+j], byte(i+1))
+			}
+		}
+	}
+
+	// Verify last partial block (464 bytes) is all zeros
+	sparseStart := 3 * blockSize
+	remaining := fileSize - sparseStart
+	for j := 0; j < remaining; j++ {
+		if data[sparseStart+j] != 0 {
+			t.Fatalf("sparse block byte %d: got %#x, want 0", j, data[sparseStart+j])
+		}
+	}
+}
+
+func TestFileRead_SparseFullBlock(t *testing.T) {
+	// File with blockSize=512, size=1024. Block 0 has data, block 1 is sparse.
+	const blockSize = 512
+	const fileSize = 1024
+
+	image := make([]byte, blockSize)
+	for j := 0; j < blockSize; j++ {
+		image[j] = 0xAA
+	}
+
+	table := dataTable{
+		0: 0,
+		// block 1 is sparse
+	}
+
+	f := newTestFile(image, blockSize, fileSize, table)
+	data := readAll(t, f)
+
+	if int64(len(data)) != fileSize {
+		t.Fatalf("read %d bytes, want %d", len(data), fileSize)
+	}
+
+	// Block 0: 0xAA
+	for j := 0; j < blockSize; j++ {
+		if data[j] != 0xAA {
+			t.Fatalf("block 0 byte %d: got %#x, want 0xAA", j, data[j])
+		}
+	}
+
+	// Block 1: all zeros
+	for j := blockSize; j < fileSize; j++ {
+		if data[j] != 0 {
+			t.Fatalf("sparse block byte %d: got %#x, want 0", j-blockSize, data[j])
+		}
+	}
+}
+
+func TestFileRead_AllSparse(t *testing.T) {
+	// Entirely sparse file: blockSize=512, size=768 (1 full + 1 partial).
+	const blockSize = 512
+	const fileSize = 768
+
+	image := make([]byte, 0) // no data blocks
+	table := dataTable{}     // everything sparse
+
+	f := newTestFile(image, blockSize, fileSize, table)
+	data := readAll(t, f)
+
+	if int64(len(data)) != fileSize {
+		t.Fatalf("read %d bytes, want %d", len(data), fileSize)
+	}
+
+	for i, b := range data {
+		if b != 0 {
+			t.Fatalf("byte %d: got %#x, want 0", i, b)
+		}
+	}
+}

--- a/ext4/file_test.go
+++ b/ext4/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"io/fs"
 	"testing"
 )
 
@@ -150,6 +151,78 @@ func TestFileRead_AllSparse(t *testing.T) {
 		if b != 0 {
 			t.Fatalf("byte %d: got %#x, want 0", i, b)
 		}
+	}
+}
+
+func TestFileInfoMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		imode    uint16
+		wantType fs.FileMode
+		wantPerm fs.FileMode
+	}{
+		{"regular 0644", 0x81A4, 0, 0o644},
+		{"directory 0755", 0x41ED, fs.ModeDir, 0o755},
+		{"symlink 0777", 0xA1FF, fs.ModeSymlink, 0o777},
+		{"socket 0755", 0xC1ED, fs.ModeSocket, 0o755},
+		{"fifo 0644", 0x11A4, fs.ModeNamedPipe, 0o644},
+		{"char device 0666", 0x21B6, fs.ModeCharDevice, 0o666},
+		{"block device 0660", 0x61B0, fs.ModeDevice, 0o660},
+		{"setuid", 0x89A4, 0, 0o644 | fs.ModeSetuid},
+		{"setgid", 0x85A4, 0, 0o644 | fs.ModeSetgid},
+		{"sticky", 0x83A4, 0, 0o644 | fs.ModeSticky},
+		{"setuid+setgid+sticky", 0x8FA4, 0, 0o644 | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fi := FileInfo{
+				name:  "test",
+				inode: &Inode{Mode: tt.imode},
+			}
+			got := fi.Mode()
+
+			if got.Type() != tt.wantType {
+				t.Errorf("Type() = %v, want %v", got.Type(), tt.wantType)
+			}
+			if got.Perm() != tt.wantPerm.Perm() {
+				t.Errorf("Perm() = %o, want %o", got.Perm(), tt.wantPerm.Perm())
+			}
+			if tt.wantPerm&fs.ModeSetuid != 0 && got&fs.ModeSetuid == 0 {
+				t.Error("ModeSetuid not set")
+			}
+			if tt.wantPerm&fs.ModeSetgid != 0 && got&fs.ModeSetgid == 0 {
+				t.Error("ModeSetgid not set")
+			}
+			if tt.wantPerm&fs.ModeSticky != 0 && got&fs.ModeSticky == 0 {
+				t.Error("ModeSticky not set")
+			}
+
+			// Verify Go standard API works correctly
+			switch tt.wantType {
+			case fs.ModeDir:
+				if !got.IsDir() {
+					t.Error("IsDir() = false, want true")
+				}
+				if got.IsRegular() {
+					t.Error("IsRegular() = true, want false")
+				}
+			case 0:
+				if !got.IsRegular() {
+					t.Error("IsRegular() = false, want true")
+				}
+				if got.IsDir() {
+					t.Error("IsDir() = true, want false")
+				}
+			default:
+				if got.IsDir() {
+					t.Error("IsDir() should be false for non-dir type")
+				}
+				if got.IsRegular() {
+					t.Error("IsRegular() should be false for non-regular type")
+				}
+			}
+		})
 	}
 }
 

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -225,10 +225,185 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 	return dirEntries, nil
 }
 
+// buildDirectoryBlockMap builds a mapping from logical directory block numbers
+// to physical byte offsets for the given inode.
+func (ext4 *FileSystem) buildDirectoryBlockMap(inode *Inode) (map[uint32]int64, error) {
+	blockSize := ext4.sb.GetBlockSize()
+	m := make(map[uint32]int64)
+
+	if inode.UsesExtents() {
+		extents, err := ext4.Extents(inode)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get extents: %w", err)
+		}
+		for _, e := range extents {
+			for i := uint32(0); i < uint32(e.Len); i++ {
+				m[e.Block+i] = (e.offset() + int64(i)) * blockSize
+			}
+		}
+	} else {
+		blockAddresses, err := inode.GetBlockAddresses(ext4)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to get block addresses: %w", err)
+		}
+		for i, addr := range blockAddresses {
+			m[uint32(i)] = int64(addr) * blockSize
+		}
+	}
+
+	return m, nil
+}
+
+// readLogicalBlock reads a single logical block using a pre-built block map.
+func (ext4 *FileSystem) readLogicalBlock(blockMap map[uint32]int64, logicalBlock uint32) ([]byte, error) {
+	offset, ok := blockMap[logicalBlock]
+	if !ok {
+		return nil, xerrors.Errorf("logical block %d not found in block map", logicalBlock)
+	}
+
+	buf := make([]byte, ext4.sb.GetBlockSize())
+	_, err := ext4.r.ReadAt(buf, offset)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read block at offset %#x: %w", offset, err)
+	}
+	return buf, nil
+}
+
+// parseDxBlockNumbers extracts logical block numbers from dx_entry data.
+// data starts right after the DxCountLimit (at the block field of the header entry).
+func parseDxBlockNumbers(data []byte, count uint16) []uint32 {
+	blocks := make([]uint32, 0, count)
+
+	if count == 0 {
+		return blocks
+	}
+
+	// Header entry: only the block field (4 bytes, no hash)
+	if len(data) < 4 {
+		return blocks
+	}
+	blocks = append(blocks, binary.LittleEndian.Uint32(data[:4]))
+
+	// Remaining entries: each 8 bytes (hash:4 + block:4)
+	for i := uint16(1); i < count; i++ {
+		off := int(4 + (i-1)*8)
+		if off+8 > len(data) {
+			break
+		}
+		blocks = append(blocks, binary.LittleEndian.Uint32(data[off+4:off+8]))
+	}
+
+	return blocks
+}
+
+// collectLeafBlocks recursively traverses HTree internal nodes to collect
+// all leaf block numbers.
+func (ext4 *FileSystem) collectLeafBlocks(blockMap map[uint32]int64, nodeBlocks []uint32, remainingDepth uint8) ([]uint32, error) {
+	if remainingDepth == 0 {
+		return nodeBlocks, nil
+	}
+
+	var leafBlocks []uint32
+	for _, nodeBlock := range nodeBlocks {
+		data, err := ext4.readLogicalBlock(blockMap, nodeBlock)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read internal node block %d: %w", nodeBlock, err)
+		}
+
+		// Internal node layout:
+		// 0x00-0x07: fake dirent (8 bytes)
+		// 0x08-0x0B: DxCountLimit (4 bytes)
+		// 0x0C+: dx_entry data (block0 + remaining entries)
+		if len(data) < 0x0C {
+			return nil, xerrors.New("htree internal node block too small")
+		}
+
+		var cl DxCountLimit
+		if err := binary.Read(bytes.NewReader(data[0x08:0x0C]), binary.LittleEndian, &cl); err != nil {
+			return nil, xerrors.Errorf("failed to parse dx_countlimit in internal node: %w", err)
+		}
+
+		childBlocks := parseDxBlockNumbers(data[0x0C:], cl.Count)
+
+		leaves, err := ext4.collectLeafBlocks(blockMap, childBlocks, remainingDepth-1)
+		if err != nil {
+			return nil, err
+		}
+		leafBlocks = append(leafBlocks, leaves...)
+	}
+
+	return leafBlocks, nil
+}
+
+// listEntriesHTree reads all directory entries from an HTree-indexed directory
+// by traversing the hash tree structure and reading only leaf blocks.
+func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error) {
+	blockMap, err := ext4.buildDirectoryBlockMap(inode)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to build block map: %w", err)
+	}
+
+	// Read root block (logical block 0)
+	rootData, err := ext4.readLogicalBlock(blockMap, 0)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read htree root block: %w", err)
+	}
+
+	// Root block layout:
+	// 0x00-0x0B: dot entry (12 bytes)
+	// 0x0C-0x17: dotdot entry (12 bytes)
+	// 0x18-0x1F: DxRootInfo (8 bytes)
+	// 0x20-0x23: DxCountLimit (4 bytes)
+	// 0x24+: dx_entry data (block0 + remaining entries)
+	if len(rootData) < 0x24 {
+		return nil, xerrors.New("htree root block too small")
+	}
+
+	var rootInfo DxRootInfo
+	if err := binary.Read(bytes.NewReader(rootData[0x18:0x20]), binary.LittleEndian, &rootInfo); err != nil {
+		return nil, xerrors.Errorf("failed to parse dx_root_info: %w", err)
+	}
+
+	var cl DxCountLimit
+	if err := binary.Read(bytes.NewReader(rootData[0x20:0x24]), binary.LittleEndian, &cl); err != nil {
+		return nil, xerrors.Errorf("failed to parse dx_countlimit: %w", err)
+	}
+
+	// Collect block numbers from root dx_entries
+	rootBlocks := parseDxBlockNumbers(rootData[0x24:], cl.Count)
+
+	// Traverse tree to collect all leaf block numbers
+	leafBlocks, err := ext4.collectLeafBlocks(blockMap, rootBlocks, rootInfo.IndirectLevels)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to collect htree leaf blocks: %w", err)
+	}
+
+	// Read directory entries from each leaf block
+	var entries []DirectoryEntry2
+	for _, logBlock := range leafBlocks {
+		data, err := ext4.readLogicalBlock(blockMap, logBlock)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read leaf block %d: %w", logBlock, err)
+		}
+
+		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to extract directory entries from leaf block %d: %w", logBlock, err)
+		}
+		entries = append(entries, dirEntries...)
+	}
+
+	return entries, nil
+}
+
 func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 	inode, err := ext4.getInode(ino)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to get root inode: %w", err)
+	}
+
+	if inode.UsesDirectoryHashTree() {
+		return ext4.listEntriesHTree(inode)
 	}
 
 	if !inode.UsesExtents() {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -107,7 +107,7 @@ func (ext4 *FileSystem) readDirEntry(name string) ([]fs.DirEntry, error) {
 	var currentIno int64
 	cleanedPath := filepath.ToSlash(filepath.Clean(name))
 	dirs := strings.Split(strings.Trim(cleanedPath, "/"), "/")
-	if len(dirs) == 1 && dirs[0] == "." || dirs[0] == "" {
+	if len(dirs) == 1 && (dirs[0] == "." || dirs[0] == "") {
 		var dirEntries []fs.DirEntry
 		for _, fileInfo := range fileInfos {
 			if fileInfo.Name() == "." || fileInfo.Name() == ".." {
@@ -246,6 +246,9 @@ func (ext4 *FileSystem) buildDirectoryBlockMap(inode *Inode) (map[uint32]int64, 
 			return nil, xerrors.Errorf("failed to get block addresses: %w", err)
 		}
 		for i, addr := range blockAddresses {
+			if addr == 0 {
+				continue
+			}
 			m[uint32(i)] = int64(addr) * blockSize
 		}
 	}
@@ -392,17 +395,13 @@ func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error
 
 	// Read directory entries from each leaf block
 	var entries []DirectoryEntry2
-	buf := make([]byte, ext4.sb.GetBlockSize())
 	for _, logBlock := range leafBlocks {
-		offset, ok := blockMap[logBlock]
-		if !ok {
-			return nil, xerrors.Errorf("leaf block %d not found in block map", logBlock)
-		}
-		if _, err := ext4.r.ReadAt(buf, offset); err != nil {
-			return nil, xerrors.Errorf("failed to read leaf block %d at offset %#x: %w", logBlock, offset, err)
+		data, err := ext4.readLogicalBlock(blockMap, logBlock)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to read leaf block %d: %w", logBlock, err)
 		}
 
-		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(buf))
+		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(data))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to extract directory entries from leaf block %d: %w", logBlock, err)
 		}
@@ -415,7 +414,7 @@ func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error
 func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 	inode, err := ext4.getInode(ino)
 	if err != nil {
-		return nil, xerrors.Errorf("failed to get root inode: %w", err)
+		return nil, xerrors.Errorf("failed to get inode(%d): %w", ino, err)
 	}
 
 	if inode.UsesDirectoryHashTree() {
@@ -430,18 +429,19 @@ func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 			return nil, xerrors.Errorf("failed to get block address: %w", err)
 		}
 
+		blockSize := ext4.sb.GetBlockSize()
 		for _, blockAddress := range blockAddresses {
-			_, err = ext4.r.Seek(int64(blockAddress)*ext4.sb.GetBlockSize(), 0)
-			if err != nil {
-				return nil, xerrors.Errorf("failed to seek: %w", err)
+			if blockAddress == 0 {
+				continue
 			}
 
-			directoryReader, err := readBlock(ext4.r, ext4.sb.GetBlockSize())
+			buf := make([]byte, blockSize)
+			_, err = ext4.r.ReadAt(buf, int64(blockAddress)*blockSize)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to read directory entry: %w", err)
+				return nil, xerrors.Errorf("failed to read directory block at %#x: %w", blockAddress, err)
 			}
 
-			extracted, err := extractDirectoryEntries(directoryReader)
+			extracted, err := extractDirectoryEntries(bytes.NewBuffer(buf))
 			if err != nil {
 				return nil, xerrors.Errorf("failed to extract directory entries: %w", err)
 			}
@@ -455,18 +455,17 @@ func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 		return nil, xerrors.Errorf("failed to get extents: %w", err)
 	}
 
+	blockSize := ext4.sb.GetBlockSize()
 	var entries []DirectoryEntry2
 	for _, e := range extents {
-		_, err := ext4.r.Seek(e.offset()*ext4.sb.GetBlockSize(), 0)
+		size := blockSize * int64(e.Len)
+		buf := make([]byte, size)
+		_, err := ext4.r.ReadAt(buf, e.offset()*blockSize)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to seek: %w", err)
-		}
-		directoryReader, err := readBlock(ext4.r, ext4.sb.GetBlockSize()*int64(e.Len))
-		if err != nil {
-			return nil, xerrors.Errorf("failed to read directory entry: %w", err)
+			return nil, xerrors.Errorf("failed to read directory blocks at offset %#x: %w", e.offset()*blockSize, err)
 		}
 
-		dirEntries, err := extractDirectoryEntries(directoryReader)
+		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(buf))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to extract directory entries: %w", err)
 		}
@@ -573,8 +572,10 @@ func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, erro
 
 	dt := make(dataTable)
 	for i, blockAddress := range blockAddresses {
-		offset := int64(blockAddress) * ext4.sb.GetBlockSize()
-		dt[int64(i)] = offset
+		if blockAddress == 0 {
+			continue
+		}
+		dt[int64(i)] = int64(blockAddress) * ext4.sb.GetBlockSize()
 	}
 
 	return &File{

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -204,6 +204,9 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 			break
 		}
 		align := dirEntry.RecLen - nameAndHeader
+		if int(align) > directoryReader.Len() {
+			break
+		}
 		_, err = directoryReader.Read(make([]byte, align))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to read align: %w", err)

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -200,7 +200,11 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 			break
 		}
 
-		align := dirEntry.RecLen - uint16(dirEntry.NameLen+8)
+		nameAndHeader := uint16(dirEntry.NameLen) + 8
+		if dirEntry.RecLen < nameAndHeader {
+			break
+		}
+		align := dirEntry.RecLen - nameAndHeader
 		_, err = directoryReader.Read(make([]byte, align))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to read align: %w", err)
@@ -322,6 +326,9 @@ func (ext4 *FileSystem) collectLeafBlocks(blockMap map[uint32]int64, nodeBlocks 
 		if err := binary.Read(bytes.NewReader(data[0x08:0x0C]), binary.LittleEndian, &cl); err != nil {
 			return nil, xerrors.Errorf("failed to parse dx_countlimit in internal node: %w", err)
 		}
+		if cl.Count > cl.Limit {
+			return nil, xerrors.Errorf("htree internal node: count (%d) exceeds limit (%d)", cl.Count, cl.Limit)
+		}
 
 		childBlocks := parseDxBlockNumbers(data[0x0C:], cl.Count)
 
@@ -363,10 +370,16 @@ func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error
 	if err := binary.Read(bytes.NewReader(rootData[0x18:0x20]), binary.LittleEndian, &rootInfo); err != nil {
 		return nil, xerrors.Errorf("failed to parse dx_root_info: %w", err)
 	}
+	if rootInfo.IndirectLevels > 3 {
+		return nil, xerrors.Errorf("htree indirect_levels (%d) exceeds maximum (3)", rootInfo.IndirectLevels)
+	}
 
 	var cl DxCountLimit
 	if err := binary.Read(bytes.NewReader(rootData[0x20:0x24]), binary.LittleEndian, &cl); err != nil {
 		return nil, xerrors.Errorf("failed to parse dx_countlimit: %w", err)
+	}
+	if cl.Count > cl.Limit {
+		return nil, xerrors.Errorf("htree root: count (%d) exceeds limit (%d)", cl.Count, cl.Limit)
 	}
 
 	// Collect block numbers from root dx_entries
@@ -380,13 +393,17 @@ func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error
 
 	// Read directory entries from each leaf block
 	var entries []DirectoryEntry2
+	buf := make([]byte, ext4.sb.GetBlockSize())
 	for _, logBlock := range leafBlocks {
-		data, err := ext4.readLogicalBlock(blockMap, logBlock)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to read leaf block %d: %w", logBlock, err)
+		offset, ok := blockMap[logBlock]
+		if !ok {
+			return nil, xerrors.Errorf("leaf block %d not found in block map", logBlock)
+		}
+		if _, err := ext4.r.ReadAt(buf, offset); err != nil {
+			return nil, xerrors.Errorf("failed to read leaf block %d at offset %#x: %w", logBlock, offset, err)
 		}
 
-		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+		dirEntries, err := extractDirectoryEntries(bytes.NewBuffer(buf))
 		if err != nil {
 			return nil, xerrors.Errorf("failed to extract directory entries from leaf block %d: %w", logBlock, err)
 		}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -175,7 +175,6 @@ func (ext4 *FileSystem) listFileInfo(ino int64) ([]FileInfo, error) {
 				name:  entry.Name,
 				ino:   int64(entry.Inode),
 				inode: inode,
-				mode:  fs.FileMode(inode.Mode),
 			},
 		)
 	}
@@ -507,7 +506,6 @@ func (ext4 *FileSystem) ReadDirInfo(name string) (fs.FileInfo, error) {
 		return FileInfo{
 			name:  "/",
 			inode: inode,
-			mode:  fs.FileMode(inode.Mode),
 		}, nil
 	}
 	name = strings.TrimRight(name, "/")
@@ -554,7 +552,6 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 			name:  fileName,
 			ino:   dir.ino,
 			inode: dir.inode,
-			mode:  fs.FileMode(dir.inode.Mode),
 		}
 		var f *File
 		if fi.inode.UsesExtents() {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -206,6 +206,9 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 			return nil, xerrors.Errorf("failed to read align: %w", err)
 		}
 
+		if dirEntry.Inode == 0 {
+			continue
+		}
 		if dirEntry.Name == "." || dirEntry.Name == ".." {
 			continue
 		}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -65,7 +65,7 @@ func NewFS(r io.SectionReader, cache Cache[string, any]) (*FileSystem, error) {
 		return nil, xerrors.Errorf("failed to parse super block: %w", err)
 	}
 
-	numBlockGroups := (sb.GetBlockCount() + int64(sb.BlockPerGroup) - 1) / int64(sb.BlockPerGroup)
+	numBlockGroups := int64(sb.GetGroupDescriptorTableCount())
 	numBlockGroups2 := (sb.InodeCount + sb.InodePerGroup - 1) / sb.InodePerGroup
 	if numBlockGroups != int64(numBlockGroups2) {
 		return nil, xerrors.Errorf("Block/inode mismatch: %d %d %d", sb.GetBlockCount(), numBlockGroups, numBlockGroups2)

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/lunixbochs/struc"
@@ -601,6 +602,9 @@ func (ext4 *FileSystem) file(fi FileInfo, filePath string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
+	sort.Slice(extents, func(i, j int) bool {
+		return extents[i].Block < extents[j].Block
+	})
 
 	dt := make(dataTable)
 	for _, e := range extents {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"path"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/lunixbochs/struc"
@@ -598,13 +597,10 @@ func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, erro
 }
 
 func (ext4 *FileSystem) file(fi FileInfo, filePath string) (*File, error) {
-	extents, err := ext4.extents(fi.inode.BlockOrExtents[:], nil, extentDepthRoot)
+	extents, err := ext4.Extents(fi.inode)
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(extents, func(i, j int) bool {
-		return extents[i].Block < extents[j].Block
-	})
 
 	dt := make(dataTable)
 	for _, e := range extents {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -219,9 +219,6 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 		if dirEntry.Flags == 0xDE {
 			continue
 		}
-		if dirEntry.Flags == 0 {
-			continue
-		}
 
 		dirEntries = append(dirEntries, dirEntry)
 	}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -216,9 +216,6 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 		if dirEntry.Name == "." || dirEntry.Name == ".." {
 			continue
 		}
-		if dirEntry.Flags == 0xDE {
-			continue
-		}
 
 		dirEntries = append(dirEntries, dirEntry)
 	}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -347,7 +347,7 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 		if !ok {
 			return nil, xerrors.Errorf("unspecified error, entry is not dir entry %+v", entry)
 		}
-		if dir.inode.Mode&0xA000 == 0xA000 {
+		if dir.inode.IsSymlink() {
 			return nil, ErrOpenSymlink
 		}
 

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -370,8 +370,12 @@ func (ext4 *FileSystem) listEntriesHTree(inode *Inode) ([]DirectoryEntry2, error
 	if err := binary.Read(bytes.NewReader(rootData[0x18:0x20]), binary.LittleEndian, &rootInfo); err != nil {
 		return nil, xerrors.Errorf("failed to parse dx_root_info: %w", err)
 	}
-	if rootInfo.IndirectLevels > 3 {
-		return nil, xerrors.Errorf("htree indirect_levels (%d) exceeds maximum (3)", rootInfo.IndirectLevels)
+	maxLevels := uint8(2)
+	if ext4.sb.FeatureIncompatLargedir() {
+		maxLevels = 3
+	}
+	if rootInfo.IndirectLevels > maxLevels {
+		return nil, xerrors.Errorf("htree indirect_levels (%d) exceeds maximum (%d)", rootInfo.IndirectLevels, maxLevels)
 	}
 
 	var cl DxCountLimit

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -236,6 +236,9 @@ func (ext4 *FileSystem) buildDirectoryBlockMap(inode *Inode) (map[uint32]int64, 
 			return nil, xerrors.Errorf("failed to get extents: %w", err)
 		}
 		for _, e := range extents {
+			if e.IsUninitialized() {
+				return nil, xerrors.Errorf("failed to build directory block map: uninitialized extent at logical block %d", e.Block)
+			}
 			for i := uint32(0); i < uint32(e.GetLen()); i++ {
 				m[e.Block+i] = (e.offset() + int64(i)) * blockSize
 			}
@@ -458,6 +461,9 @@ func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 	blockSize := ext4.sb.GetBlockSize()
 	var entries []DirectoryEntry2
 	for _, e := range extents {
+		if e.IsUninitialized() {
+			return nil, xerrors.Errorf("failed to list directory entries: uninitialized extent at logical block %d", e.Block)
+		}
 		size := blockSize * int64(e.GetLen())
 		buf := make([]byte, size)
 		_, err := ext4.r.ReadAt(buf, e.offset()*blockSize)

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -597,7 +597,7 @@ func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, erro
 }
 
 func (ext4 *FileSystem) file(fi FileInfo, filePath string) (*File, error) {
-	extents, err := ext4.extents(fi.inode.BlockOrExtents[:], nil)
+	extents, err := ext4.extents(fi.inode.BlockOrExtents[:], nil, extentDepthRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -236,7 +236,7 @@ func (ext4 *FileSystem) buildDirectoryBlockMap(inode *Inode) (map[uint32]int64, 
 			return nil, xerrors.Errorf("failed to get extents: %w", err)
 		}
 		for _, e := range extents {
-			for i := uint32(0); i < uint32(e.Len); i++ {
+			for i := uint32(0); i < uint32(e.GetLen()); i++ {
 				m[e.Block+i] = (e.offset() + int64(i)) * blockSize
 			}
 		}
@@ -458,7 +458,7 @@ func (ext4 *FileSystem) listEntries(ino int64) ([]DirectoryEntry2, error) {
 	blockSize := ext4.sb.GetBlockSize()
 	var entries []DirectoryEntry2
 	for _, e := range extents {
-		size := blockSize * int64(e.Len)
+		size := blockSize * int64(e.GetLen())
 		buf := make([]byte, size)
 		_, err := ext4.r.ReadAt(buf, e.offset()*blockSize)
 		if err != nil {
@@ -598,8 +598,13 @@ func (ext4 *FileSystem) file(fi FileInfo, filePath string) (*File, error) {
 
 	dt := make(dataTable)
 	for _, e := range extents {
+		// Uninitialized (unwritten) extents should read as zeros;
+		// omitting them from the table delegates to the sparse path in Read().
+		if e.IsUninitialized() {
+			continue
+		}
 		offset := e.offset() * ext4.sb.GetBlockSize()
-		for i := int64(0); i < int64(e.Len); i++ {
+		for i := int64(0); i < int64(e.GetLen()); i++ {
 			dt[int64(e.Block)+i] = offset + i*ext4.sb.GetBlockSize()
 		}
 	}

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -210,6 +210,7 @@ func extractDirectoryEntries(directoryReader *bytes.Buffer) ([]DirectoryEntry2, 
 			return nil, xerrors.Errorf("failed to read align: %w", err)
 		}
 
+		// inode == 0 means the entry is unused (deleted or padding such as checksum tail).
 		if dirEntry.Inode == 0 {
 			continue
 		}

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -455,7 +455,6 @@ func TestListEntriesHTreeRootBlockReadFailure(t *testing.T) {
 func TestCollectLeafBlocksInternalNodeCountZero(t *testing.T) {
 	const blockSize = 4096
 
-	// Image with root block and an internal node that is too small (< 0x0C meaningful bytes)
 	totalSize := 6 * blockSize
 	image := make([]byte, totalSize)
 
@@ -463,12 +462,8 @@ func TestCollectLeafBlocksInternalNodeCountZero(t *testing.T) {
 	rootBlock := buildHTreeRootBlock(blockSize, 1, []uint32{1})
 	copy(image[4*blockSize:], rootBlock)
 
-	// Internal node at physical block 5 (logical block 1): fill with zeros (too small / invalid)
-	// All zeros means the fake dirent and DxCountLimit are zero.
-	// This is a valid parse but count=0, so no child blocks. Not an error per se.
-	// To trigger the "too small" error, we need len(data) < 0x0C, but readLogicalBlock
-	// always returns blockSize bytes. So this path can only fail if ReadAt fails.
-	// Let's instead test that count=0 in internal node returns no entries gracefully.
+	// Internal node at physical block 5 (logical block 1): all zeros.
+	// DxCountLimit.Count=0, so no child blocks are returned.
 
 	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
 	ext4fs := &FileSystem{
@@ -618,41 +613,84 @@ func TestListEntriesHTreeCountExceedsLimit(t *testing.T) {
 	}
 }
 
-func TestListEntriesHTreeIndirectLevelsTooHigh(t *testing.T) {
+func TestListEntriesHTreeInternalNodeCountExceedsLimit(t *testing.T) {
 	const blockSize = 4096
 
-	totalSize := 5 * blockSize
+	// Root (indirect_levels=1) -> internal node with count > limit
+	totalSize := 6 * blockSize
 	image := make([]byte, totalSize)
 
-	// Build root block with indirect_levels=4 (exceeds max 3)
-	rootBlock := buildHTreeRootBlock(blockSize, 4, []uint32{1})
+	rootBlock := buildHTreeRootBlock(blockSize, 1, []uint32{1})
 	copy(image[4*blockSize:], rootBlock)
 
-	rootInode := &Inode{
-		Mode:   0x4000 | 0755,
-		Flags:  INDEX_FL | EXTENTS_FL,
-		SizeLo: uint32(blockSize),
-	}
+	// Internal node at physical block 5: limit=2, count=10 (corrupted)
+	node := make([]byte, blockSize)
+	binary.LittleEndian.PutUint32(node[0x00:], 0)
+	binary.LittleEndian.PutUint16(node[0x04:], uint16(blockSize))
+	binary.LittleEndian.PutUint16(node[0x08:], 2)  // limit
+	binary.LittleEndian.PutUint16(node[0x0A:], 10) // count > limit
+	copy(image[5*blockSize:], node)
+
+	rootInode := &Inode{Mode: 0x4000 | 0755, Flags: INDEX_FL | EXTENTS_FL, SizeLo: 2 * uint32(blockSize)}
 	var extBuf bytes.Buffer
-	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
-		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
-	})
-	binary.Write(&extBuf, binary.LittleEndian, &Extent{
-		Block: 0, Len: 1, StartHi: 0, StartLo: 4,
-	})
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{Block: 0, Len: 2, StartHi: 0, StartLo: 4})
 	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
 
 	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
-	ext4fs := &FileSystem{
-		r:     sr,
-		sb:    Superblock{LogBlockSize: 2},
-		cache: &mockCache[string, any]{},
-	}
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
 
 	_, err := ext4fs.listEntriesHTree(rootInode)
 	if err == nil {
-		t.Fatal("expected error for indirect_levels > 3, got nil")
+		t.Fatal("expected error for internal node count > limit, got nil")
 	}
+}
+
+func TestListEntriesHTreeIndirectLevelsTooHigh(t *testing.T) {
+	const blockSize = 4096
+
+	// Without LARGEDIR: max is 2, so levels=3 should be rejected
+	t.Run("without LARGEDIR", func(t *testing.T) {
+		totalSize := 5 * blockSize
+		image := make([]byte, totalSize)
+		copy(image[4*blockSize:], buildHTreeRootBlock(blockSize, 3, []uint32{1}))
+
+		rootInode := &Inode{Mode: 0x4000 | 0755, Flags: INDEX_FL | EXTENTS_FL, SizeLo: uint32(blockSize)}
+		var extBuf bytes.Buffer
+		binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0})
+		binary.Write(&extBuf, binary.LittleEndian, &Extent{Block: 0, Len: 1, StartHi: 0, StartLo: 4})
+		copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+		sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+		ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+		_, err := ext4fs.listEntriesHTree(rootInode)
+		if err == nil {
+			t.Fatal("expected error for indirect_levels=3 without LARGEDIR")
+		}
+	})
+
+	// With LARGEDIR: max is 3, so levels=4 should be rejected
+	t.Run("with LARGEDIR", func(t *testing.T) {
+		totalSize := 5 * blockSize
+		image := make([]byte, totalSize)
+		copy(image[4*blockSize:], buildHTreeRootBlock(blockSize, 4, []uint32{1}))
+
+		rootInode := &Inode{Mode: 0x4000 | 0755, Flags: INDEX_FL | EXTENTS_FL, SizeLo: uint32(blockSize)}
+		var extBuf bytes.Buffer
+		binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0})
+		binary.Write(&extBuf, binary.LittleEndian, &Extent{Block: 0, Len: 1, StartHi: 0, StartLo: 4})
+		copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+		sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+		sb := Superblock{LogBlockSize: 2, FeatureIncompat: FEATURE_INCOMPAT_LARGEDIR}
+		ext4fs := &FileSystem{r: sr, sb: sb, cache: &mockCache[string, any]{}}
+
+		_, err := ext4fs.listEntriesHTree(rootInode)
+		if err == nil {
+			t.Fatal("expected error for indirect_levels=4 with LARGEDIR")
+		}
+	})
 }
 
 func TestExtractDirectoryEntriesRecLenUnderflow(t *testing.T) {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -968,6 +968,56 @@ func TestBuildDirectoryBlockMapSkipsZero(t *testing.T) {
 	}
 }
 
+func TestBuildDirectoryBlockMapExtents(t *testing.T) {
+	const blockSize = 4096
+
+	// Inode with EXTENTS_FL: two extents
+	// Extent 1: logical blocks 0-1 at physical blocks 10-11
+	// Extent 2: logical block 2 at physical block 20
+	inode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  EXTENTS_FL,
+		SizeLo: 3 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 2, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 2, StartHi: 0, StartLo: 10,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 2, Len: 1, StartHi: 0, StartLo: 20,
+	})
+	copy(inode.BlockOrExtents[:], extBuf.Bytes())
+
+	image := make([]byte, 25*blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	m, err := ext4fs.buildDirectoryBlockMap(inode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Logical block 0 -> physical block 10 -> offset 10*4096
+	if offset, ok := m[0]; !ok || offset != 10*blockSize {
+		t.Errorf("block 0: got offset=%d ok=%v, want %d", offset, ok, 10*blockSize)
+	}
+	// Logical block 1 -> physical block 11 -> offset 11*4096
+	if offset, ok := m[1]; !ok || offset != 11*blockSize {
+		t.Errorf("block 1: got offset=%d ok=%v, want %d", offset, ok, 11*blockSize)
+	}
+	// Logical block 2 -> physical block 20 -> offset 20*4096
+	if offset, ok := m[2]; !ok || offset != 20*blockSize {
+		t.Errorf("block 2: got offset=%d ok=%v, want %d", offset, ok, 20*blockSize)
+	}
+
+	if len(m) != 3 {
+		t.Errorf("expected 3 entries in block map, got %d", len(m))
+	}
+}
+
 // --- fileFromBlock zero-skip test ---
 
 func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -1,0 +1,85 @@
+package ext4
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func buildDirEntry(inode uint32, name string, flags uint8) []byte {
+	nameBytes := []byte(name)
+	nameLen := uint8(len(nameBytes))
+	recLen := uint16(8 + len(nameBytes))
+	// align to 4 bytes
+	if recLen%4 != 0 {
+		recLen += 4 - recLen%4
+	}
+
+	buf := make([]byte, recLen)
+	binary.LittleEndian.PutUint32(buf[0:4], inode)
+	binary.LittleEndian.PutUint16(buf[4:6], recLen)
+	buf[6] = nameLen
+	buf[7] = flags
+	copy(buf[8:], nameBytes)
+	return buf
+}
+
+func TestExtractDirectoryEntriesSkipsInodeZero(t *testing.T) {
+	var data []byte
+	data = append(data, buildDirEntry(10, "valid_file", 1)...)
+	data = append(data, buildDirEntry(0, "deleted_file", 1)...)
+	data = append(data, buildDirEntry(20, "another_file", 2)...)
+
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Name != "valid_file" {
+		t.Errorf("expected first entry 'valid_file', got %q", entries[0].Name)
+	}
+	if entries[1].Name != "another_file" {
+		t.Errorf("expected second entry 'another_file', got %q", entries[1].Name)
+	}
+}
+
+func TestExtractDirectoryEntriesSkipsDotEntries(t *testing.T) {
+	var data []byte
+	data = append(data, buildDirEntry(2, ".", 2)...)
+	data = append(data, buildDirEntry(2, "..", 2)...)
+	data = append(data, buildDirEntry(11, "real", 1)...)
+
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "real" {
+		t.Errorf("expected 'real', got %q", entries[0].Name)
+	}
+}
+
+func TestExtractDirectoryEntriesSkipsDeletedChecksum(t *testing.T) {
+	var data []byte
+	data = append(data, buildDirEntry(5, "keep", 1)...)
+	data = append(data, buildDirEntry(6, "csum", 0xDE)...)
+	data = append(data, buildDirEntry(7, "notype", 0)...)
+
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "keep" {
+		t.Errorf("expected 'keep', got %q", entries[0].Name)
+	}
+}

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -422,6 +422,129 @@ func TestListEntriesHTreeBlockAddressing(t *testing.T) {
 	}
 }
 
+func TestListEntriesHTreeRootBlockReadFailure(t *testing.T) {
+	// Image too small: ReadAt will fail when trying to read the root block
+	smallImage := make([]byte, 16)
+	sr := io.NewSectionReader(bytes.NewReader(smallImage), 0, 16)
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2}, // 4096 byte blocks
+		cache: &mockCache[string, any]{},
+	}
+
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: uint32(4096),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 1, StartHi: 0, StartLo: 0,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	_, err := ext4fs.listEntriesHTree(rootInode)
+	if err == nil {
+		t.Fatal("expected error for root block read failure, got nil")
+	}
+}
+
+func TestCollectLeafBlocksInternalNodeTooSmall(t *testing.T) {
+	const blockSize = 4096
+
+	// Image with root block and an internal node that is too small (< 0x0C meaningful bytes)
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	// Root block at physical block 4, indirect_levels=1, points to internal node at logical block 1
+	rootBlock := buildHTreeRootBlock(blockSize, 1, []uint32{1})
+	copy(image[4*blockSize:], rootBlock)
+
+	// Internal node at physical block 5 (logical block 1): fill with zeros (too small / invalid)
+	// All zeros means the fake dirent and DxCountLimit are zero.
+	// This is a valid parse but count=0, so no child blocks. Not an error per se.
+	// To trigger the "too small" error, we need len(data) < 0x0C, but readLogicalBlock
+	// always returns blockSize bytes. So this path can only fail if ReadAt fails.
+	// Let's instead test that count=0 in internal node returns no entries gracefully.
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: 2 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 2, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	entries, err := ext4fs.listEntriesHTree(rootInode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries from empty internal node, got %d", len(entries))
+	}
+}
+
+func TestReadLogicalBlockMissingBlock(t *testing.T) {
+	const blockSize = 4096
+
+	image := make([]byte, blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(blockSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	blockMap := map[uint32]int64{
+		0: 0,
+	}
+
+	// Read existing block - should succeed
+	_, err := ext4fs.readLogicalBlock(blockMap, 0)
+	if err != nil {
+		t.Fatalf("unexpected error reading existing block: %v", err)
+	}
+
+	// Read missing block - should fail
+	_, err = ext4fs.readLogicalBlock(blockMap, 99)
+	if err == nil {
+		t.Fatal("expected error for missing logical block, got nil")
+	}
+}
+
+func TestParseDxBlockNumbersTruncatedData(t *testing.T) {
+	// count=3 but data only has room for header entry + 1 regular entry (not 2)
+	data := make([]byte, 4+8)                    // block0(4) + entry1(8), missing entry2
+	binary.LittleEndian.PutUint32(data[0:], 10)  // block0
+	binary.LittleEndian.PutUint32(data[4:], 100) // hash1
+	binary.LittleEndian.PutUint32(data[8:], 20)  // block1
+
+	got := parseDxBlockNumbers(data, 3)
+	// Should get 2 blocks (10, 20) since entry2 data is missing
+	if len(got) != 2 {
+		t.Fatalf("expected 2 blocks from truncated data, got %d", len(got))
+	}
+	if got[0] != 10 || got[1] != 20 {
+		t.Errorf("expected [10, 20], got %v", got)
+	}
+}
+
 func TestListEntriesDispatchesToHTree(t *testing.T) {
 	const blockSize = 4096
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"io/fs"
+	"strings"
 	"testing"
 )
 
@@ -1018,6 +1019,41 @@ func TestBuildDirectoryBlockMapExtents(t *testing.T) {
 	}
 }
 
+func TestBuildDirectoryBlockMapRejectsUninitializedExtent(t *testing.T) {
+	const blockSize = 4096
+
+	inode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  EXTENTS_FL,
+		SizeLo: 2 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 2, Max: 4, Depth: 0,
+	})
+	// Extent 1: initialized
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 1, StartHi: 0, StartLo: 10,
+	})
+	// Extent 2: uninitialized (bit 15 set)
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 1, Len: 0x8001, StartHi: 0, StartLo: 20,
+	})
+	copy(inode.BlockOrExtents[:], extBuf.Bytes())
+
+	image := make([]byte, 25*blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	_, err := ext4fs.buildDirectoryBlockMap(inode)
+	if err == nil {
+		t.Fatal("expected error for uninitialized extent in directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to build directory block map: uninitialized extent") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 // --- fileFromBlock zero-skip test ---
 
 func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {
@@ -1245,6 +1281,50 @@ func TestListEntriesExtentReadAt(t *testing.T) {
 		if !names[expected] {
 			t.Errorf("expected %q in entries", expected)
 		}
+	}
+}
+
+func TestListEntriesExtentRejectsUninitializedExtent(t *testing.T) {
+	const blockSize = 4096
+
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	// Build root inode (inode 2) with an uninitialized extent
+	rootInode := Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  EXTENTS_FL,
+		SizeLo: uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 0x8001, StartHi: 0, StartLo: 4, // uninitialized
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	var inodeBuf bytes.Buffer
+	binary.Write(&inodeBuf, binary.LittleEndian, &rootInode)
+	copy(image[2*blockSize+256:], inodeBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+
+	_, err := ext4fs.listEntries(rootInodeNumber)
+	if err == nil {
+		t.Fatal("expected error for uninitialized extent in directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to list directory entries: uninitialized extent") {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -1048,6 +1048,85 @@ func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {
 	}
 }
 
+// --- listEntries non-HTree extent path ---
+
+func TestListEntriesExtentReadAt(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout:
+	// Block 2: inode table
+	// Block 4: directory block (logical block 0) with entries
+	// Block 5: directory block (logical block 1) with entries
+
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	// Directory entries at physical block 4
+	// In real ext4, the last entry in a block has RecLen padded to fill the block.
+	var block0Data []byte
+	block0Data = append(block0Data, buildDirEntry(2, ".", 2)...)
+	block0Data = append(block0Data, buildDirEntry(2, "..", 2)...)
+	extAEntry := buildDirEntry(100, "extA", 1)
+	// Pad last entry's RecLen to fill the rest of block 4
+	binary.LittleEndian.PutUint16(extAEntry[4:6], uint16(blockSize-len(block0Data)))
+	block0Data = append(block0Data, extAEntry...)
+	copy(image[4*blockSize:], block0Data)
+
+	// Directory entries at physical block 5
+	var block1Data []byte
+	block1Data = append(block1Data, buildDirEntry(101, "extB", 1)...)
+	copy(image[5*blockSize:], block1Data)
+
+	// Build root inode (inode 2) — directory with EXTENTS_FL, no INDEX_FL
+	rootInode := Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  EXTENTS_FL, // extent-based, no HTree
+		SizeLo: 2 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 2, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	// Write inode to inode table: block 2, index 1 (inode 2 = index 1)
+	var inodeBuf bytes.Buffer
+	binary.Write(&inodeBuf, binary.LittleEndian, &rootInode)
+	copy(image[2*blockSize+256:], inodeBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+
+	entries, err := ext4fs.listEntries(rootInodeNumber)
+	if err != nil {
+		t.Fatalf("listEntries failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name] = true
+	}
+	for _, expected := range []string{"extA", "extB"} {
+		if !names[expected] {
+			t.Errorf("expected %q in entries", expected)
+		}
+	}
+}
+
 // --- listEntries non-HTree block addressing path ---
 
 func TestListEntriesBlockAddressingReadAt(t *testing.T) {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -3,6 +3,7 @@ package ext4
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"testing"
 )
 
@@ -81,5 +82,404 @@ func TestExtractDirectoryEntriesSkipsDeletedChecksum(t *testing.T) {
 	}
 	if entries[0].Name != "keep" {
 		t.Errorf("expected 'keep', got %q", entries[0].Name)
+	}
+}
+
+func TestParseDxBlockNumbers(t *testing.T) {
+	tests := []struct {
+		name   string
+		count  uint16
+		data   []byte
+		expect []uint32
+	}{
+		{
+			name:  "single entry (header only)",
+			count: 1,
+			data: func() []byte {
+				b := make([]byte, 4)
+				binary.LittleEndian.PutUint32(b, 5)
+				return b
+			}(),
+			expect: []uint32{5},
+		},
+		{
+			name:  "three entries",
+			count: 3,
+			data: func() []byte {
+				// block0(4) + entry1(hash:4+block:4) + entry2(hash:4+block:4)
+				b := make([]byte, 4+8+8)
+				binary.LittleEndian.PutUint32(b[0:], 10)   // block0
+				binary.LittleEndian.PutUint32(b[4:], 100)  // hash1
+				binary.LittleEndian.PutUint32(b[8:], 20)   // block1
+				binary.LittleEndian.PutUint32(b[12:], 200) // hash2
+				binary.LittleEndian.PutUint32(b[16:], 30)  // block2
+				return b
+			}(),
+			expect: []uint32{10, 20, 30},
+		},
+		{
+			name:   "empty data",
+			count:  1,
+			data:   []byte{},
+			expect: []uint32{},
+		},
+		{
+			name:   "count zero",
+			count:  0,
+			data:   make([]byte, 32),
+			expect: []uint32{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDxBlockNumbers(tt.data, tt.count)
+			if len(got) != len(tt.expect) {
+				t.Fatalf("expected %d blocks, got %d", len(tt.expect), len(got))
+			}
+			for i := range tt.expect {
+				if got[i] != tt.expect[i] {
+					t.Errorf("block[%d] = %d, want %d", i, got[i], tt.expect[i])
+				}
+			}
+		})
+	}
+}
+
+// buildHTreeRootBlock constructs an HTree root block with the given parameters.
+func buildHTreeRootBlock(blockSize int, indirectLevels uint8, leafBlocks []uint32) []byte {
+	block := make([]byte, blockSize)
+
+	// dot entry: inode=2, rec_len=12, name_len=1, file_type=2
+	binary.LittleEndian.PutUint32(block[0x00:], 2)
+	binary.LittleEndian.PutUint16(block[0x04:], 12)
+	block[0x06] = 1
+	block[0x07] = 2
+	block[0x08] = '.'
+
+	// dotdot entry: inode=2, rec_len=blockSize-12, name_len=2, file_type=2
+	binary.LittleEndian.PutUint32(block[0x0C:], 2)
+	binary.LittleEndian.PutUint16(block[0x10:], uint16(blockSize-12))
+	block[0x12] = 2
+	block[0x13] = 2
+	block[0x14] = '.'
+	block[0x15] = '.'
+
+	// dx_root_info at 0x18
+	binary.LittleEndian.PutUint32(block[0x18:], 0) // reserved_zero
+	block[0x1C] = 1                                // hash_version
+	block[0x1D] = 8                                // info_length
+	block[0x1E] = indirectLevels
+	block[0x1F] = 0
+
+	// DxCountLimit at 0x20
+	count := uint16(len(leafBlocks))
+	binary.LittleEndian.PutUint16(block[0x20:], 100) // limit
+	binary.LittleEndian.PutUint16(block[0x22:], count)
+
+	// dx_entries starting at 0x24
+	// header entry: block0
+	if len(leafBlocks) > 0 {
+		binary.LittleEndian.PutUint32(block[0x24:], leafBlocks[0])
+	}
+	// remaining entries: hash + block
+	for i := 1; i < len(leafBlocks); i++ {
+		off := 0x28 + (i-1)*8
+		binary.LittleEndian.PutUint32(block[off:], uint32(i*0x1000)) // hash
+		binary.LittleEndian.PutUint32(block[off+4:], leafBlocks[i])  // block
+	}
+
+	return block
+}
+
+// buildHTreeInternalNode constructs an HTree internal node block.
+func buildHTreeInternalNode(blockSize int, childBlocks []uint32) []byte {
+	block := make([]byte, blockSize)
+
+	// fake dirent: inode=0, rec_len=blockSize, name_len=0, file_type=0
+	binary.LittleEndian.PutUint32(block[0x00:], 0)
+	binary.LittleEndian.PutUint16(block[0x04:], uint16(blockSize))
+	block[0x06] = 0
+	block[0x07] = 0
+
+	// DxCountLimit at 0x08
+	count := uint16(len(childBlocks))
+	binary.LittleEndian.PutUint16(block[0x08:], 100) // limit
+	binary.LittleEndian.PutUint16(block[0x0A:], count)
+
+	// dx_entries starting at 0x0C
+	if len(childBlocks) > 0 {
+		binary.LittleEndian.PutUint32(block[0x0C:], childBlocks[0])
+	}
+	for i := 1; i < len(childBlocks); i++ {
+		off := 0x10 + (i-1)*8
+		binary.LittleEndian.PutUint32(block[off:], uint32(i*0x1000)) // hash
+		binary.LittleEndian.PutUint32(block[off+4:], childBlocks[i]) // block
+	}
+
+	return block
+}
+
+func TestListEntriesHTreeDirect(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout:
+	// Block 4: HTree root (logical dir block 0)
+	// Block 5: Leaf block (logical dir block 1) with entries
+	// Block 6: Leaf block (logical dir block 2) with entries
+
+	totalSize := 7 * blockSize
+	image := make([]byte, totalSize)
+
+	// HTree root at physical block 4 - points to leaf blocks 1 and 2
+	rootBlock := buildHTreeRootBlock(blockSize, 0, []uint32{1, 2})
+	copy(image[4*blockSize:], rootBlock)
+
+	// Leaf block at physical block 5 (logical dir block 1)
+	var leaf1Data []byte
+	leaf1Data = append(leaf1Data, buildDirEntry(100, "hello.txt", 1)...)
+	leaf1Data = append(leaf1Data, buildDirEntry(101, "world.txt", 1)...)
+	copy(image[5*blockSize:], leaf1Data)
+
+	// Leaf block at physical block 6 (logical dir block 2)
+	var leaf2Data []byte
+	leaf2Data = append(leaf2Data, buildDirEntry(102, "foo.txt", 1)...)
+	copy(image[6*blockSize:], leaf2Data)
+
+	// Build inode with extent tree: 3 logical blocks starting at physical block 4
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: 3 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 3, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	// Construct FileSystem directly
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2}, // blockSize = 4096
+		cache: &mockCache[string, any]{},
+	}
+
+	entries, err := ext4fs.listEntriesHTree(rootInode)
+	if err != nil {
+		t.Fatalf("listEntriesHTree failed: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name] = true
+	}
+	for _, expected := range []string{"hello.txt", "world.txt", "foo.txt"} {
+		if !names[expected] {
+			t.Errorf("expected %q in entries", expected)
+		}
+	}
+}
+
+func TestListEntriesHTreeWithInternalNodes(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout:
+	// Block 4: HTree root (logical dir block 0), indirect_levels=1
+	//   -> points to internal nodes at logical blocks 1 and 2
+	// Block 5: Internal node (logical dir block 1) -> leaf blocks 3, 4
+	// Block 6: Internal node (logical dir block 2) -> leaf block 5
+	// Block 7: Leaf block (logical dir block 3)
+	// Block 8: Leaf block (logical dir block 4)
+	// Block 9: Leaf block (logical dir block 5)
+
+	totalSize := 10 * blockSize
+	image := make([]byte, totalSize)
+
+	// HTree root at physical block 4, indirect_levels=1
+	rootBlock := buildHTreeRootBlock(blockSize, 1, []uint32{1, 2})
+	copy(image[4*blockSize:], rootBlock)
+
+	// Internal node at physical block 5 (logical block 1) -> leaf blocks 3 and 4
+	internalNode1 := buildHTreeInternalNode(blockSize, []uint32{3, 4})
+	copy(image[5*blockSize:], internalNode1)
+
+	// Internal node at physical block 6 (logical block 2) -> leaf block 5
+	internalNode2 := buildHTreeInternalNode(blockSize, []uint32{5})
+	copy(image[6*blockSize:], internalNode2)
+
+	// Leaf blocks
+	var leaf3 []byte
+	leaf3 = append(leaf3, buildDirEntry(10, "aaa", 1)...)
+	copy(image[7*blockSize:], leaf3)
+
+	var leaf4 []byte
+	leaf4 = append(leaf4, buildDirEntry(11, "bbb", 1)...)
+	copy(image[8*blockSize:], leaf4)
+
+	var leaf5 []byte
+	leaf5 = append(leaf5, buildDirEntry(12, "ccc", 1)...)
+	copy(image[9*blockSize:], leaf5)
+
+	// Build inode: 6 logical blocks starting at physical block 4
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: 6 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 6, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	entries, err := ext4fs.listEntriesHTree(rootInode)
+	if err != nil {
+		t.Fatalf("listEntriesHTree failed: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name] = true
+	}
+	for _, expected := range []string{"aaa", "bbb", "ccc"} {
+		if !names[expected] {
+			t.Errorf("expected %q in entries", expected)
+		}
+	}
+}
+
+func TestListEntriesHTreeBlockAddressing(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout (same as TestListEntriesHTreeDirect but using block addressing):
+	// Block 4: HTree root (logical dir block 0)
+	// Block 5: Leaf block (logical dir block 1)
+
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	rootBlock := buildHTreeRootBlock(blockSize, 0, []uint32{1})
+	copy(image[4*blockSize:], rootBlock)
+
+	var leafData []byte
+	leafData = append(leafData, buildDirEntry(100, "block_file", 1)...)
+	copy(image[5*blockSize:], leafData)
+
+	// Build inode with block addressing (no EXTENTS_FL)
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL, // no EXTENTS_FL
+		SizeLo: 2 * uint32(blockSize),
+	}
+	// BlockAddressing: direct blocks [0]=4, [1]=5
+	ba := BlockAddressing{}
+	ba.DirectBlock[0] = 4
+	ba.DirectBlock[1] = 5
+	var baBuf bytes.Buffer
+	binary.Write(&baBuf, binary.LittleEndian, &ba)
+	copy(rootInode.BlockOrExtents[:], baBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	entries, err := ext4fs.listEntriesHTree(rootInode)
+	if err != nil {
+		t.Fatalf("listEntriesHTree failed: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "block_file" {
+		t.Errorf("expected 'block_file', got %q", entries[0].Name)
+	}
+}
+
+func TestListEntriesDispatchesToHTree(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout:
+	// Block 2: inode table
+	// Block 4: HTree root (logical dir block 0)
+	// Block 5: Leaf block (logical dir block 1)
+
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	rootBlock := buildHTreeRootBlock(blockSize, 0, []uint32{1})
+	copy(image[4*blockSize:], rootBlock)
+
+	var leafData []byte
+	leafData = append(leafData, buildDirEntry(100, "dispatched", 1)...)
+	copy(image[5*blockSize:], leafData)
+
+	// Build root inode (inode 2) at inode table block 2, index 1
+	rootInode := Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: 2 * uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 2, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	// Write inode to inode table: block 2, index 1 (inode 2 = index 1)
+	var inodeBuf bytes.Buffer
+	binary.Write(&inodeBuf, binary.LittleEndian, &rootInode)
+	copy(image[2*blockSize+256:], inodeBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+
+	// Call listEntries (not listEntriesHTree) to verify dispatch
+	entries, err := ext4fs.listEntries(rootInodeNumber)
+	if err != nil {
+		t.Fatalf("listEntries failed: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Name != "dispatched" {
+		t.Errorf("expected 'dispatched', got %q", entries[0].Name)
 	}
 }

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -1048,6 +1048,77 @@ func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {
 	}
 }
 
+// --- File.Read partial last block test ---
+
+func TestFileReadPartialLastBlock(t *testing.T) {
+	const blockSize = 4096
+	// File size = 1.5 blocks = 6144 bytes
+	fileSize := int64(blockSize + blockSize/2)
+
+	image := make([]byte, 16*blockSize)
+
+	// Write known data to physical block 10 (full block: 0xAA)
+	for i := 0; i < blockSize; i++ {
+		image[10*blockSize+i] = 0xAA
+	}
+	// Write known data to physical block 11 (full block: 0xBB, but only half should be read)
+	for i := 0; i < blockSize; i++ {
+		image[11*blockSize+i] = 0xBB
+	}
+
+	directBlocks := [12]uint32{10, 11}
+	inode := buildBlockAddressingInode(directBlocks, 0, 0, 0, fileSize)
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	fi := FileInfo{
+		name:  "partial.bin",
+		inode: inode,
+		mode:  fs.FileMode(inode.Mode),
+	}
+	f, err := ext4fs.fileFromBlock(fi, "partial.bin")
+	if err != nil {
+		t.Fatalf("fileFromBlock failed: %v", err)
+	}
+
+	// Read entire file
+	var all []byte
+	buf := make([]byte, 1024)
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			all = append(all, buf[:n]...)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+	}
+
+	if int64(len(all)) != fileSize {
+		t.Fatalf("total bytes read = %d, want %d", len(all), fileSize)
+	}
+
+	// First block should be 0xAA
+	for i := 0; i < blockSize; i++ {
+		if all[i] != 0xAA {
+			t.Errorf("byte[%d] = %#x, want 0xAA", i, all[i])
+			break
+		}
+	}
+
+	// Second block (partial) should be 0xBB for exactly blockSize/2 bytes
+	for i := blockSize; i < int(fileSize); i++ {
+		if all[i] != 0xBB {
+			t.Errorf("byte[%d] = %#x, want 0xBB", i, all[i])
+			break
+		}
+	}
+}
+
 // --- listEntries non-HTree extent path ---
 
 func TestListEntriesExtentReadAt(t *testing.T) {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -738,12 +738,12 @@ func TestExtractDirectoryEntriesRecLenUnderflow(t *testing.T) {
 func TestExtractDirectoryEntriesRecLenOverflow(t *testing.T) {
 	// Build a valid entry followed by an entry whose RecLen exceeds remaining buffer.
 	// The first entry should be returned; the second should cause parsing to stop.
-	first := buildDirEntry(10, "hello", 1)     // valid entry
-	second := make([]byte, 12)                  // entry with oversized RecLen
-	binary.LittleEndian.PutUint32(second[0:], 20) // inode=20
+	first := buildDirEntry(10, "hello", 1)            // valid entry
+	second := make([]byte, 12)                        // entry with oversized RecLen
+	binary.LittleEndian.PutUint32(second[0:], 20)     // inode=20
 	binary.LittleEndian.PutUint16(second[4:], 0xFFFF) // rec_len=65535 (way beyond buffer)
-	second[6] = 3                               // name_len=3
-	second[7] = 1                               // flags
+	second[6] = 3                                     // name_len=3
+	second[7] = 1                                     // flags
 	copy(second[8:], []byte("foo"))
 
 	buf := append(first, second...)

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -66,10 +66,11 @@ func TestExtractDirectoryEntriesSkipsDotEntries(t *testing.T) {
 	}
 }
 
-func TestExtractDirectoryEntriesSkipsChecksum(t *testing.T) {
+func TestExtractDirectoryEntriesSkipsChecksumTail(t *testing.T) {
+	// Checksum tail entries have inode=0 and file_type=0xDE; skipped by inode==0 guard
 	var data []byte
 	data = append(data, buildDirEntry(5, "keep", 1)...)
-	data = append(data, buildDirEntry(6, "csum", 0xDE)...)
+	data = append(data, buildDirEntry(0, "csum", 0xDE)...)
 
 	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
 	if err != nil {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -735,6 +735,30 @@ func TestExtractDirectoryEntriesRecLenUnderflow(t *testing.T) {
 	}
 }
 
+func TestExtractDirectoryEntriesRecLenOverflow(t *testing.T) {
+	// Build a valid entry followed by an entry whose RecLen exceeds remaining buffer.
+	// The first entry should be returned; the second should cause parsing to stop.
+	first := buildDirEntry(10, "hello", 1)     // valid entry
+	second := make([]byte, 12)                  // entry with oversized RecLen
+	binary.LittleEndian.PutUint32(second[0:], 20) // inode=20
+	binary.LittleEndian.PutUint16(second[4:], 0xFFFF) // rec_len=65535 (way beyond buffer)
+	second[6] = 3                               // name_len=3
+	second[7] = 1                               // flags
+	copy(second[8:], []byte("foo"))
+
+	buf := append(first, second...)
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(buf))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry (first valid), got %d", len(entries))
+	}
+	if len(entries) > 0 && entries[0].Name != "hello" {
+		t.Errorf("expected first entry name 'hello', got %q", entries[0].Name)
+	}
+}
+
 func TestListEntriesDispatchesToHTree(t *testing.T) {
 	const blockSize = 4096
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -66,11 +66,10 @@ func TestExtractDirectoryEntriesSkipsDotEntries(t *testing.T) {
 	}
 }
 
-func TestExtractDirectoryEntriesSkipsDeletedChecksum(t *testing.T) {
+func TestExtractDirectoryEntriesSkipsChecksum(t *testing.T) {
 	var data []byte
 	data = append(data, buildDirEntry(5, "keep", 1)...)
 	data = append(data, buildDirEntry(6, "csum", 0xDE)...)
-	data = append(data, buildDirEntry(7, "notype", 0)...)
 
 	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
 	if err != nil {
@@ -82,6 +81,28 @@ func TestExtractDirectoryEntriesSkipsDeletedChecksum(t *testing.T) {
 	}
 	if entries[0].Name != "keep" {
 		t.Errorf("expected 'keep', got %q", entries[0].Name)
+	}
+}
+
+func TestExtractDirectoryEntriesKeepsUnknownFileType(t *testing.T) {
+	// file_type=0 (EXT4_FT_UNKNOWN) is valid on filesystems without FEATURE_INCOMPAT_FILETYPE
+	var data []byte
+	data = append(data, buildDirEntry(5, "known", 1)...)
+	data = append(data, buildDirEntry(7, "unknown_type", 0)...)
+
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(data))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Name != "known" {
+		t.Errorf("expected 'known', got %q", entries[0].Name)
+	}
+	if entries[1].Name != "unknown_type" {
+		t.Errorf("expected 'unknown_type', got %q", entries[1].Name)
 	}
 }
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
-	"io/fs"
 	"strings"
 	"testing"
 )
@@ -1079,7 +1078,6 @@ func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {
 	fi := FileInfo{
 		name:  "sparse.bin",
 		inode: inode,
-		mode:  fs.FileMode(inode.Mode),
 	}
 	f, err := ext4fs.fileFromBlock(fi, "sparse.bin")
 	if err != nil {
@@ -1161,7 +1159,6 @@ func TestFileReadPartialLastBlock(t *testing.T) {
 	fi := FileInfo{
 		name:  "partial.bin",
 		inode: inode,
-		mode:  fs.FileMode(inode.Mode),
 	}
 	f, err := ext4fs.fileFromBlock(fi, "partial.bin")
 	if err != nil {

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -452,7 +452,7 @@ func TestListEntriesHTreeRootBlockReadFailure(t *testing.T) {
 	}
 }
 
-func TestCollectLeafBlocksInternalNodeTooSmall(t *testing.T) {
+func TestCollectLeafBlocksInternalNodeCountZero(t *testing.T) {
 	const blockSize = 4096
 
 	// Image with root block and an internal node that is too small (< 0x0C meaningful bytes)
@@ -542,6 +542,135 @@ func TestParseDxBlockNumbersTruncatedData(t *testing.T) {
 	}
 	if got[0] != 10 || got[1] != 20 {
 		t.Errorf("expected [10, 20], got %v", got)
+	}
+}
+
+func TestDxCountLimitParsing(t *testing.T) {
+	data := make([]byte, 4)
+	binary.LittleEndian.PutUint16(data[0:], 200) // limit at offset 0
+	binary.LittleEndian.PutUint16(data[2:], 5)   // count at offset 2
+
+	var cl DxCountLimit
+	if err := binary.Read(bytes.NewReader(data), binary.LittleEndian, &cl); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cl.Limit != 200 {
+		t.Errorf("Limit = %d, want 200", cl.Limit)
+	}
+	if cl.Count != 5 {
+		t.Errorf("Count = %d, want 5", cl.Count)
+	}
+}
+
+func TestListEntriesHTreeCountExceedsLimit(t *testing.T) {
+	const blockSize = 4096
+
+	totalSize := 5 * blockSize
+	image := make([]byte, totalSize)
+
+	// Build root block with count > limit (corrupted)
+	block := make([]byte, blockSize)
+	// dot entry
+	binary.LittleEndian.PutUint32(block[0x00:], 2)
+	binary.LittleEndian.PutUint16(block[0x04:], 12)
+	block[0x06] = 1
+	block[0x07] = 2
+	block[0x08] = '.'
+	// dotdot entry
+	binary.LittleEndian.PutUint32(block[0x0C:], 2)
+	binary.LittleEndian.PutUint16(block[0x10:], uint16(blockSize-12))
+	block[0x12] = 2
+	block[0x13] = 2
+	block[0x14] = '.'
+	block[0x15] = '.'
+	// dx_root_info
+	block[0x1E] = 0 // indirect_levels
+	// DxCountLimit: limit=2, count=10 (count > limit)
+	binary.LittleEndian.PutUint16(block[0x20:], 2)
+	binary.LittleEndian.PutUint16(block[0x22:], 10)
+
+	copy(image[4*blockSize:], block)
+
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 1, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	_, err := ext4fs.listEntriesHTree(rootInode)
+	if err == nil {
+		t.Fatal("expected error for count > limit, got nil")
+	}
+}
+
+func TestListEntriesHTreeIndirectLevelsTooHigh(t *testing.T) {
+	const blockSize = 4096
+
+	totalSize := 5 * blockSize
+	image := make([]byte, totalSize)
+
+	// Build root block with indirect_levels=4 (exceeds max 3)
+	rootBlock := buildHTreeRootBlock(blockSize, 4, []uint32{1})
+	copy(image[4*blockSize:], rootBlock)
+
+	rootInode := &Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  INDEX_FL | EXTENTS_FL,
+		SizeLo: uint32(blockSize),
+	}
+	var extBuf bytes.Buffer
+	binary.Write(&extBuf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&extBuf, binary.LittleEndian, &Extent{
+		Block: 0, Len: 1, StartHi: 0, StartLo: 4,
+	})
+	copy(rootInode.BlockOrExtents[:], extBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:     sr,
+		sb:    Superblock{LogBlockSize: 2},
+		cache: &mockCache[string, any]{},
+	}
+
+	_, err := ext4fs.listEntriesHTree(rootInode)
+	if err == nil {
+		t.Fatal("expected error for indirect_levels > 3, got nil")
+	}
+}
+
+func TestExtractDirectoryEntriesRecLenUnderflow(t *testing.T) {
+	// Build an entry where RecLen < NameLen + 8 (corrupted)
+	buf := make([]byte, 20)
+	binary.LittleEndian.PutUint32(buf[0:], 1) // inode
+	binary.LittleEndian.PutUint16(buf[4:], 5) // rec_len=5, but name_len=10 → 10+8=18 > 5
+	buf[6] = 10                               // name_len=10
+	buf[7] = 1                                // flags
+	copy(buf[8:], []byte("abcdefghij"))       // name (10 bytes, extends beyond rec_len)
+
+	entries, err := extractDirectoryEntries(bytes.NewBuffer(buf))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should stop parsing at corrupted entry, returning no entries
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries from corrupted RecLen, got %d", len(entries))
 	}
 }
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -804,8 +804,8 @@ func TestListEntriesDispatchesToHTree(t *testing.T) {
 // and the given file size.
 func buildBlockAddressingInode(directBlocks [12]uint32, singleIndirect, doubleIndirect, tripleIndirect uint32, fileSize int64) *Inode {
 	inode := &Inode{
-		Mode:   0x8000 | 0644,
-		SizeLo: uint32(fileSize),
+		Mode:     0x8000 | 0644,
+		SizeLo:   uint32(fileSize),
 		SizeHigh: uint32(fileSize >> 32),
 	}
 	ba := BlockAddressing{
@@ -861,7 +861,7 @@ func TestGetBlockAddressesSparseIndirectBlock(t *testing.T) {
 	// Contains: [100, 0, 200] — middle entry is a hole
 	indirectBlock := make([]byte, blockSize)
 	binary.LittleEndian.PutUint32(indirectBlock[0:], 100)
-	binary.LittleEndian.PutUint32(indirectBlock[4:], 0)   // hole
+	binary.LittleEndian.PutUint32(indirectBlock[4:], 0) // hole
 	binary.LittleEndian.PutUint32(indirectBlock[8:], 200)
 	copy(image[16*blockSize:], indirectBlock)
 

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"io/fs"
 	"testing"
 )
 
@@ -793,5 +794,329 @@ func TestListEntriesDispatchesToHTree(t *testing.T) {
 	}
 	if entries[0].Name != "dispatched" {
 		t.Errorf("expected 'dispatched', got %q", entries[0].Name)
+	}
+}
+
+// --- GetBlockAddresses sparse tests ---
+
+// buildBlockAddressingInode creates an Inode with block addressing (no EXTENTS_FL)
+// and the given file size.
+func buildBlockAddressingInode(directBlocks [12]uint32, singleIndirect, doubleIndirect, tripleIndirect uint32, fileSize int64) *Inode {
+	inode := &Inode{
+		Mode:   0x8000 | 0644,
+		SizeLo: uint32(fileSize),
+		SizeHigh: uint32(fileSize >> 32),
+	}
+	ba := BlockAddressing{
+		DirectBlock:         directBlocks,
+		SingleIndirectBlock: singleIndirect,
+		DoubleIndirectBlock: doubleIndirect,
+		TripleIndirectBlock: tripleIndirect,
+	}
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, &ba)
+	copy(inode.BlockOrExtents[:], buf.Bytes())
+	return inode
+}
+
+func TestGetBlockAddressesSparseDirectBlocks(t *testing.T) {
+	const blockSize = 4096
+
+	// Direct blocks: [5, 0, 7] — block 1 is a hole
+	directBlocks := [12]uint32{5, 0, 7}
+	inode := buildBlockAddressingInode(directBlocks, 0, 0, 0, 3*blockSize)
+
+	image := make([]byte, 8*blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	addrs, err := inode.GetBlockAddresses(ext4fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(addrs) != 3 {
+		t.Fatalf("expected 3 addresses, got %d", len(addrs))
+	}
+	if addrs[0] != 5 {
+		t.Errorf("addrs[0] = %d, want 5", addrs[0])
+	}
+	if addrs[1] != 0 {
+		t.Errorf("addrs[1] = %d, want 0 (hole)", addrs[1])
+	}
+	if addrs[2] != 7 {
+		t.Errorf("addrs[2] = %d, want 7", addrs[2])
+	}
+}
+
+func TestGetBlockAddressesSparseIndirectBlock(t *testing.T) {
+	const blockSize = 4096
+
+	// 12 direct blocks + 3 blocks via single indirect (with a hole at index 1)
+	totalBlocks := int64(15)
+	image := make([]byte, 20*blockSize)
+
+	// Single indirect block at physical block 16
+	// Contains: [100, 0, 200] — middle entry is a hole
+	indirectBlock := make([]byte, blockSize)
+	binary.LittleEndian.PutUint32(indirectBlock[0:], 100)
+	binary.LittleEndian.PutUint32(indirectBlock[4:], 0)   // hole
+	binary.LittleEndian.PutUint32(indirectBlock[8:], 200)
+	copy(image[16*blockSize:], indirectBlock)
+
+	directBlocks := [12]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	inode := buildBlockAddressingInode(directBlocks, 16, 0, 0, totalBlocks*blockSize)
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	addrs, err := inode.GetBlockAddresses(ext4fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if int64(len(addrs)) != totalBlocks {
+		t.Fatalf("expected %d addresses, got %d", totalBlocks, len(addrs))
+	}
+
+	// Check direct blocks [0-11]
+	for i := 0; i < 12; i++ {
+		if addrs[i] != uint32(i+1) {
+			t.Errorf("addrs[%d] = %d, want %d", i, addrs[i], i+1)
+		}
+	}
+	// Check indirect blocks [12-14]
+	if addrs[12] != 100 {
+		t.Errorf("addrs[12] = %d, want 100", addrs[12])
+	}
+	if addrs[13] != 0 {
+		t.Errorf("addrs[13] = %d, want 0 (hole)", addrs[13])
+	}
+	if addrs[14] != 200 {
+		t.Errorf("addrs[14] = %d, want 200", addrs[14])
+	}
+}
+
+func TestGetBlockAddressesNullIndirectPointers(t *testing.T) {
+	const blockSize = 4096
+
+	// 14 blocks total: 12 direct + 2 more needed, but SingleIndirectBlock=0 (null pointer).
+	// The null pointer path should emit zeros for the remaining 2 blocks.
+	totalBlocks := int64(14)
+	directBlocks := [12]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	inode := buildBlockAddressingInode(directBlocks, 0, 0, 0, totalBlocks*blockSize)
+
+	image := make([]byte, blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	addrs, err := inode.GetBlockAddresses(ext4fs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if int64(len(addrs)) != totalBlocks {
+		t.Fatalf("expected %d addresses, got %d", totalBlocks, len(addrs))
+	}
+
+	// Direct blocks [0-11] should have real addresses
+	for i := 0; i < 12; i++ {
+		if addrs[i] != uint32(i+1) {
+			t.Errorf("addrs[%d] = %d, want %d", i, addrs[i], i+1)
+		}
+	}
+	// Blocks [12-13] should be zero (null indirect pointer)
+	if addrs[12] != 0 {
+		t.Errorf("addrs[12] = %d, want 0 (null indirect pointer)", addrs[12])
+	}
+	if addrs[13] != 0 {
+		t.Errorf("addrs[13] = %d, want 0 (null indirect pointer)", addrs[13])
+	}
+}
+
+// --- buildDirectoryBlockMap zero-skip test ---
+
+func TestBuildDirectoryBlockMapSkipsZero(t *testing.T) {
+	const blockSize = 4096
+
+	// Direct blocks: [4, 0, 6] — block 1 is a hole
+	directBlocks := [12]uint32{4, 0, 6}
+	inode := buildBlockAddressingInode(directBlocks, 0, 0, 0, 3*blockSize)
+	// Override mode to directory
+	inode.Mode = 0x4000 | 0755
+
+	image := make([]byte, 8*blockSize)
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	m, err := ext4fs.buildDirectoryBlockMap(inode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Block 0 -> offset 4*4096
+	if offset, ok := m[0]; !ok || offset != 4*blockSize {
+		t.Errorf("block 0: got offset=%d ok=%v, want %d", offset, ok, 4*blockSize)
+	}
+	// Block 1 should NOT be in the map (hole)
+	if _, ok := m[1]; ok {
+		t.Errorf("block 1 should not be in map (hole)")
+	}
+	// Block 2 -> offset 6*4096
+	if offset, ok := m[2]; !ok || offset != 6*blockSize {
+		t.Errorf("block 2: got offset=%d ok=%v, want %d", offset, ok, 6*blockSize)
+	}
+}
+
+// --- fileFromBlock zero-skip test ---
+
+func TestFileFromBlockSkipsZeroAddresses(t *testing.T) {
+	const blockSize = 4096
+
+	// 3 blocks: [10, 0, 12] — block 1 is a hole
+	directBlocks := [12]uint32{10, 0, 12}
+	inode := buildBlockAddressingInode(directBlocks, 0, 0, 0, 3*blockSize)
+
+	image := make([]byte, 16*blockSize)
+
+	// Write known data to block 10 and 12
+	for i := range image[10*blockSize : 11*blockSize] {
+		image[10*blockSize+i] = 0xAA
+	}
+	for i := range image[12*blockSize : 13*blockSize] {
+		image[12*blockSize+i] = 0xCC
+	}
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(len(image)))
+	ext4fs := &FileSystem{r: sr, sb: Superblock{LogBlockSize: 2}, cache: &mockCache[string, any]{}}
+
+	fi := FileInfo{
+		name:  "sparse.bin",
+		inode: inode,
+		mode:  fs.FileMode(inode.Mode),
+	}
+	f, err := ext4fs.fileFromBlock(fi, "sparse.bin")
+	if err != nil {
+		t.Fatalf("fileFromBlock failed: %v", err)
+	}
+
+	// Block 0 (physical 10) should be in table
+	if _, ok := f.table[0]; !ok {
+		t.Error("block 0 should be in data table")
+	}
+	// Block 1 (hole) should NOT be in table
+	if _, ok := f.table[1]; ok {
+		t.Error("block 1 (hole) should not be in data table")
+	}
+	// Block 2 (physical 12) should be in table
+	if _, ok := f.table[2]; !ok {
+		t.Error("block 2 should be in data table")
+	}
+
+	// Read block 0 — should be 0xAA
+	buf := make([]byte, blockSize)
+	n, err := f.Read(buf)
+	if err != nil {
+		t.Fatalf("Read block 0 failed: %v", err)
+	}
+	if n != blockSize {
+		t.Fatalf("Read block 0: got %d bytes, want %d", n, blockSize)
+	}
+	if buf[0] != 0xAA || buf[blockSize-1] != 0xAA {
+		t.Errorf("block 0 data: got %#x...%#x, want 0xAA", buf[0], buf[blockSize-1])
+	}
+
+	// Read block 1 — hole, should be zeros
+	n, err = f.Read(buf)
+	if err != nil {
+		t.Fatalf("Read block 1 (hole) failed: %v", err)
+	}
+	for i, b := range buf[:n] {
+		if b != 0 {
+			t.Errorf("block 1 (hole) byte[%d] = %#x, want 0", i, b)
+			break
+		}
+	}
+
+	// Read block 2 — should be 0xCC
+	n, err = f.Read(buf)
+	if err != nil {
+		t.Fatalf("Read block 2 failed: %v", err)
+	}
+	if buf[0] != 0xCC || buf[n-1] != 0xCC {
+		t.Errorf("block 2 data: got %#x...%#x, want 0xCC", buf[0], buf[n-1])
+	}
+}
+
+// --- listEntries non-HTree block addressing path ---
+
+func TestListEntriesBlockAddressingReadAt(t *testing.T) {
+	const blockSize = 4096
+
+	// Physical layout:
+	// Block 2: inode table
+	// Block 4: directory block (logical block 0) with entries
+	// Block 5: directory block (logical block 1) with entries
+
+	totalSize := 6 * blockSize
+	image := make([]byte, totalSize)
+
+	// Directory entries at physical block 4
+	var block0Data []byte
+	block0Data = append(block0Data, buildDirEntry(2, ".", 2)...)
+	block0Data = append(block0Data, buildDirEntry(2, "..", 2)...)
+	block0Data = append(block0Data, buildDirEntry(100, "fileA", 1)...)
+	copy(image[4*blockSize:], block0Data)
+
+	// Directory entries at physical block 5
+	var block1Data []byte
+	block1Data = append(block1Data, buildDirEntry(101, "fileB", 1)...)
+	copy(image[5*blockSize:], block1Data)
+
+	// Build root inode (inode 2) — directory with block addressing, no EXTENTS_FL, no INDEX_FL
+	rootInode := Inode{
+		Mode:   0x4000 | 0755,
+		Flags:  0, // no EXTENTS_FL, no INDEX_FL
+		SizeLo: 2 * uint32(blockSize),
+	}
+	ba := BlockAddressing{}
+	ba.DirectBlock[0] = 4
+	ba.DirectBlock[1] = 5
+	var baBuf bytes.Buffer
+	binary.Write(&baBuf, binary.LittleEndian, &ba)
+	copy(rootInode.BlockOrExtents[:], baBuf.Bytes())
+
+	// Write inode to inode table: block 2, index 1 (inode 2 = index 1)
+	var inodeBuf bytes.Buffer
+	binary.Write(&inodeBuf, binary.LittleEndian, &rootInode)
+	copy(image[2*blockSize+256:], inodeBuf.Bytes())
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+
+	entries, err := ext4fs.listEntries(rootInodeNumber)
+	if err != nil {
+		t.Fatalf("listEntries failed: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name] = true
+	}
+	for _, expected := range []string{"fileA", "fileB"} {
+		if !names[expected] {
+			t.Errorf("expected %q in entries", expected)
+		}
 	}
 }

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -92,31 +92,31 @@ type BlockAddressing struct {
 	TripleIndirectBlock uint32     `struc:"uint32,little"`
 }
 
-func (i Inode) IsDir() bool {
+func (i *Inode) IsDir() bool {
 	return (i.Mode & FileTypeMask) == FileTypeDir
 }
 
-func (i Inode) IsRegular() bool {
+func (i *Inode) IsRegular() bool {
 	return (i.Mode & FileTypeMask) == FileTypeRegular
 }
 
-func (i Inode) IsSocket() bool {
+func (i *Inode) IsSocket() bool {
 	return (i.Mode & FileTypeMask) == FileTypeSocket
 }
 
-func (i Inode) IsSymlink() bool {
+func (i *Inode) IsSymlink() bool {
 	return (i.Mode & FileTypeMask) == FileTypeSymlink
 }
 
-func (i Inode) IsFifo() bool {
+func (i *Inode) IsFifo() bool {
 	return (i.Mode & FileTypeMask) == FileTypeFifo
 }
 
-func (i Inode) IsCharDevice() bool {
+func (i *Inode) IsCharDevice() bool {
 	return (i.Mode & FileTypeMask) == FileTypeCharDevice
 }
 
-func (i Inode) IsBlockDevice() bool {
+func (i *Inode) IsBlockDevice() bool {
 	return (i.Mode & FileTypeMask) == FileTypeBlockDevice
 }
 

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -27,7 +27,7 @@ type Extent struct {
 // IsUninitialized returns true if this extent is unwritten (allocated but
 // not yet written). Reads from such extents should return zeros.
 func (e *Extent) IsUninitialized() bool {
-	return e.Len > 0x7FFF
+	return e.Len&0x8000 != 0
 }
 
 // GetLen returns the actual number of blocks, masking off the

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -81,19 +81,31 @@ type BlockAddressing struct {
 }
 
 func (i Inode) IsDir() bool {
-	return i.Mode&0x4000 != 0 && i.Mode&0x8000 == 0
+	return i.Mode&0xF000 == 0x4000
 }
 
 func (i Inode) IsRegular() bool {
-	return i.Mode&0x8000 != 0 && i.Mode&0x4000 == 0
+	return i.Mode&0xF000 == 0x8000
 }
 
 func (i Inode) IsSocket() bool {
-	return i.Mode&0xC000 != 0
+	return i.Mode&0xF000 == 0xC000
 }
 
 func (i Inode) IsSymlink() bool {
-	return i.Mode&0xA000 != 0
+	return i.Mode&0xF000 == 0xA000
+}
+
+func (i Inode) IsFifo() bool {
+	return i.Mode&0xF000 == 0x1000
+}
+
+func (i Inode) IsCharDevice() bool {
+	return i.Mode&0xF000 == 0x2000
+}
+
+func (i Inode) IsBlockDevice() bool {
+	return i.Mode&0xF000 == 0x6000
 }
 
 // UsesExtents

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -24,6 +24,18 @@ type Extent struct {
 	StartLo uint32 `struc:"uint32,little"`
 }
 
+// IsUninitialized returns true if this extent is unwritten (allocated but
+// not yet written). Reads from such extents should return zeros.
+func (e *Extent) IsUninitialized() bool {
+	return e.Len > 0x7FFF
+}
+
+// GetLen returns the actual number of blocks, masking off the
+// uninitialized flag in bit 15.
+func (e *Extent) GetLen() uint16 {
+	return e.Len & 0x7FFF
+}
+
 // DirectoryEntry2 is more or less a flat file that maps an arbitrary byte string
 type DirectoryEntry2 struct {
 	Inode   uint32 `struc:"uint32,little"`

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -247,6 +247,24 @@ func (i *Inode) GetBlockAddresses(ext4 *FileSystem) ([]uint32, error) {
 	return blockAddresses, nil
 }
 
+// DxRootInfo holds the hash tree root metadata, located at offset 0x18 in the
+// root directory block (immediately after the dot and dotdot fake dirents).
+type DxRootInfo struct {
+	ReservedZero   uint32 `struc:"uint32,little"`
+	HashVersion    uint8  `struc:"uint8"`
+	InfoLength     uint8  `struc:"uint8"`
+	IndirectLevels uint8  `struc:"uint8"`
+	UnusedFlags    uint8  `struc:"uint8"`
+}
+
+// DxCountLimit is the count/limit header at the start of a dx_entry array.
+// It reinterprets the first dx_entry: the first 2 bytes are limit, the next 2
+// are count, followed by the block number for the leftmost subtree.
+type DxCountLimit struct {
+	Limit uint16 `struc:"uint16,little"`
+	Count uint16 `struc:"uint16,little"`
+}
+
 // ExtentInternal
 type ExtentInternal struct {
 	Block    uint32 `struc:"uint32,little"`

--- a/ext4/inode.go
+++ b/ext4/inode.go
@@ -123,125 +123,173 @@ func (i *Inode) GetSize() int64 {
 	return (int64(i.SizeHigh) << 32) | int64(i.SizeLo)
 }
 
-func resolveSingleIndirectBlockAddress(ext4 *FileSystem, singleIndirectBlockAddress uint32) ([]uint32, error) {
+// readIndirectBlockPointers reads all block pointers from an indirect block
+// using ReadAt. Returns up to entriesPerBlock (blockSize/4) entries including
+// zeros (sparse holes).
+func readIndirectBlockPointers(ext4 *FileSystem, blockAddr uint32, remaining int64) ([]uint32, error) {
+	blockSize := ext4.sb.GetBlockSize()
+	buf := make([]byte, blockSize)
+	_, err := ext4.r.ReadAt(buf, int64(blockAddr)*blockSize)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read indirect block at %#x: %w", blockAddr, err)
+	}
+
+	entriesPerBlock := blockSize / 4
+	count := remaining
+	if count > entriesPerBlock {
+		count = entriesPerBlock
+	}
+
+	addrs := make([]uint32, count)
+	for j := int64(0); j < count; j++ {
+		addrs[j] = binary.LittleEndian.Uint32(buf[j*4 : j*4+4])
+	}
+	return addrs, nil
+}
+
+func resolveSingleIndirectBlockAddress(ext4 *FileSystem, blockAddr uint32, remaining int64) ([]uint32, error) {
+	return readIndirectBlockPointers(ext4, blockAddr, remaining)
+}
+
+func resolveDoubleIndirectBlockAddress(ext4 *FileSystem, blockAddr uint32, remaining int64) ([]uint32, error) {
+	blockSize := ext4.sb.GetBlockSize()
+	entriesPerBlock := blockSize / 4
+
+	pointers, err := readIndirectBlockPointers(ext4, blockAddr, entriesPerBlock)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read double indirect block: %w", err)
+	}
+
 	var blockAddresses []uint32
-
-	_, err := ext4.r.Seek(int64(singleIndirectBlockAddress)*ext4.sb.GetBlockSize(), 0)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to seek: %w", err)
-	}
-
-	singleIndirectBlockAddresses, err := readBlock(ext4.r, ext4.sb.GetBlockSize())
-	if err != nil {
-		return nil, xerrors.Errorf("failed to read directory entry at block address %#x: %w", singleIndirectBlockAddress, err)
-	}
-
-	for singleIndirectBlockAddresses.Len() > 0 {
-		address := binary.LittleEndian.Uint32(singleIndirectBlockAddresses.Next(4))
-		if address == 0 {
+	for _, singleAddr := range pointers {
+		if remaining <= 0 {
 			break
 		}
-		blockAddresses = append(blockAddresses, address)
+		if singleAddr == 0 {
+			// Null pointer: emit zeros for the entire single indirect range
+			zeros := remaining
+			if zeros > entriesPerBlock {
+				zeros = entriesPerBlock
+			}
+			blockAddresses = append(blockAddresses, make([]uint32, zeros)...)
+			remaining -= zeros
+			continue
+		}
+		addrs, err := resolveSingleIndirectBlockAddress(ext4, singleAddr, remaining)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to resolve single indirect block: %w", err)
+		}
+		blockAddresses = append(blockAddresses, addrs...)
+		remaining -= int64(len(addrs))
 	}
-
 	return blockAddresses, nil
 }
 
-func resolveDoubleIndirectBlockAddress(ext4 *FileSystem, doubleIndirectBlockAddress uint32) ([]uint32, error) {
+func resolveTripleIndirectBlockAddress(ext4 *FileSystem, blockAddr uint32, remaining int64) ([]uint32, error) {
+	blockSize := ext4.sb.GetBlockSize()
+	entriesPerBlock := blockSize / 4
+	blocksPerDouble := entriesPerBlock * entriesPerBlock
+
+	pointers, err := readIndirectBlockPointers(ext4, blockAddr, entriesPerBlock)
+	if err != nil {
+		return nil, xerrors.Errorf("failed to read triple indirect block: %w", err)
+	}
+
 	var blockAddresses []uint32
-
-	_, err := ext4.r.Seek(int64(doubleIndirectBlockAddress)*ext4.sb.GetBlockSize(), 0)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to seek: %w", err)
-	}
-
-	doubleIndirectBlockAddresses, err := readBlock(ext4.r, ext4.sb.GetBlockSize())
-	if err != nil {
-		return nil, xerrors.Errorf("failed to read directory entry at block address %#x: %w", doubleIndirectBlockAddress, err)
-	}
-
-	for doubleIndirectBlockAddresses.Len() > 0 {
-		singleIndirectBlockAddress := binary.LittleEndian.Uint32(doubleIndirectBlockAddresses.Next(4))
-		if singleIndirectBlockAddress == 0 {
+	for _, doubleAddr := range pointers {
+		if remaining <= 0 {
 			break
 		}
-
-		singleIndirectBlockAddresses, err := resolveSingleIndirectBlockAddress(ext4, singleIndirectBlockAddress)
+		if doubleAddr == 0 {
+			// Null pointer: emit zeros for the entire double indirect range
+			zeros := remaining
+			if zeros > blocksPerDouble {
+				zeros = blocksPerDouble
+			}
+			blockAddresses = append(blockAddresses, make([]uint32, zeros)...)
+			remaining -= zeros
+			continue
+		}
+		addrs, err := resolveDoubleIndirectBlockAddress(ext4, doubleAddr, remaining)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read single indirect block addressing: %w", err)
+			return nil, xerrors.Errorf("failed to resolve double indirect block: %w", err)
 		}
-		blockAddresses = append(blockAddresses, singleIndirectBlockAddresses...)
+		blockAddresses = append(blockAddresses, addrs...)
+		remaining -= int64(len(addrs))
 	}
-
-	return blockAddresses, nil
-}
-
-func resolveTripleIndirectBlockAddress(ext4 *FileSystem, tripleIndirectBlockAddress uint32) ([]uint32, error) {
-	var blockAddresses []uint32
-
-	_, err := ext4.r.Seek(int64(tripleIndirectBlockAddress)*ext4.sb.GetBlockSize(), 0)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to seek: %w", err)
-	}
-
-	tripleIndirectBlockAddresses, err := readBlock(ext4.r, ext4.sb.GetBlockSize())
-	if err != nil {
-		return nil, xerrors.Errorf("failed to read directory entry at block address %#x: %w", tripleIndirectBlockAddress, err)
-	}
-
-	for tripleIndirectBlockAddresses.Len() > 0 {
-		doubleIndirectBlockAddress := binary.LittleEndian.Uint32(tripleIndirectBlockAddresses.Next(4))
-		if doubleIndirectBlockAddress == 0 {
-			break
-		}
-
-		doubleIndirectBlockAddresses, err := resolveDoubleIndirectBlockAddress(ext4, doubleIndirectBlockAddress)
-		if err != nil {
-			return nil, xerrors.Errorf("failed to read double indirect block addressing: %w", err)
-		}
-		blockAddresses = append(blockAddresses, doubleIndirectBlockAddresses...)
-	}
-
 	return blockAddresses, nil
 }
 
 func (i *Inode) GetBlockAddresses(ext4 *FileSystem) ([]uint32, error) {
+	blockSize := ext4.sb.GetBlockSize()
+	totalBlocks := (i.GetSize() + blockSize - 1) / blockSize
+	if totalBlocks == 0 {
+		return nil, nil
+	}
+
 	addresses := BlockAddressing{}
 	err := binary.Read(bytes.NewReader(i.BlockOrExtents[:]), binary.LittleEndian, &addresses)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to read block addressing: %w", err)
 	}
 
-	var blockAddresses []uint32
-	for _, blockAddress := range addresses.DirectBlock {
-		if blockAddress == 0 {
-			break
-		}
-		blockAddresses = append(blockAddresses, blockAddress)
+	blockAddresses := make([]uint32, 0, totalBlocks)
+
+	// Direct blocks (up to 12)
+	directCount := totalBlocks
+	if directCount > 12 {
+		directCount = 12
+	}
+	for j := int64(0); j < directCount; j++ {
+		blockAddresses = append(blockAddresses, addresses.DirectBlock[j])
 	}
 
-	if addresses.SingleIndirectBlock != 0 {
-		singleIndirectBlockAddresses, err := resolveSingleIndirectBlockAddress(ext4, addresses.SingleIndirectBlock)
+	remaining := totalBlocks - int64(len(blockAddresses))
+
+	if remaining > 0 && addresses.SingleIndirectBlock != 0 {
+		addrs, err := resolveSingleIndirectBlockAddress(ext4, addresses.SingleIndirectBlock, remaining)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read single indirect block addressing: %w", err)
+			return nil, xerrors.Errorf("failed to resolve single indirect block: %w", err)
 		}
-		blockAddresses = append(blockAddresses, singleIndirectBlockAddresses...)
+		blockAddresses = append(blockAddresses, addrs...)
+		remaining -= int64(len(addrs))
+	} else if remaining > 0 {
+		// Null single indirect pointer: emit zeros
+		entriesPerBlock := blockSize / 4
+		zeros := remaining
+		if zeros > entriesPerBlock {
+			zeros = entriesPerBlock
+		}
+		blockAddresses = append(blockAddresses, make([]uint32, zeros)...)
+		remaining -= zeros
 	}
 
-	if addresses.DoubleIndirectBlock != 0 {
-		doubleIndirectBlockAddresses, err := resolveDoubleIndirectBlockAddress(ext4, addresses.DoubleIndirectBlock)
+	if remaining > 0 && addresses.DoubleIndirectBlock != 0 {
+		addrs, err := resolveDoubleIndirectBlockAddress(ext4, addresses.DoubleIndirectBlock, remaining)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read double indirect block addressing: %w", err)
+			return nil, xerrors.Errorf("failed to resolve double indirect block: %w", err)
 		}
-		blockAddresses = append(blockAddresses, doubleIndirectBlockAddresses...)
+		blockAddresses = append(blockAddresses, addrs...)
+		remaining -= int64(len(addrs))
+	} else if remaining > 0 {
+		entriesPerBlock := blockSize / 4
+		blocksPerDouble := entriesPerBlock * entriesPerBlock
+		zeros := remaining
+		if zeros > blocksPerDouble {
+			zeros = blocksPerDouble
+		}
+		blockAddresses = append(blockAddresses, make([]uint32, zeros)...)
+		remaining -= zeros
 	}
 
-	if addresses.TripleIndirectBlock != 0 {
-		tripleIndirectBlockAddresses, err := resolveTripleIndirectBlockAddress(ext4, addresses.TripleIndirectBlock)
+	if remaining > 0 && addresses.TripleIndirectBlock != 0 {
+		addrs, err := resolveTripleIndirectBlockAddress(ext4, addresses.TripleIndirectBlock, remaining)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to read triple indirect block addressing: %w", err)
+			return nil, xerrors.Errorf("failed to resolve triple indirect block: %w", err)
 		}
-		blockAddresses = append(blockAddresses, tripleIndirectBlockAddresses...)
+		blockAddresses = append(blockAddresses, addrs...)
+	} else if remaining > 0 {
+		blockAddresses = append(blockAddresses, make([]uint32, remaining)...)
 	}
 
 	return blockAddresses, nil

--- a/ext4/inode_test.go
+++ b/ext4/inode_test.go
@@ -79,6 +79,34 @@ func TestInodeFileType(t *testing.T) {
 	}
 }
 
+func TestExtent_IsUninitialized(t *testing.T) {
+	tests := []struct {
+		name   string
+		len    uint16
+		wantUn bool
+		wantN  uint16
+	}{
+		{"initialized: 1 block", 1, false, 1},
+		{"initialized: max (0x7FFF)", 0x7FFF, false, 0x7FFF},
+		{"uninitialized: 1 block (0x8001)", 0x8001, true, 1},
+		{"uninitialized: max (0xFFFF)", 0xFFFF, true, 0x7FFF},
+		{"zero length", 0, false, 0},
+		{"exactly 0x8000 (uninitialized, 0 blocks)", 0x8000, true, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Extent{Len: tt.len}
+			if got := e.IsUninitialized(); got != tt.wantUn {
+				t.Errorf("IsUninitialized() = %v, want %v", got, tt.wantUn)
+			}
+			if got := e.GetLen(); got != tt.wantN {
+				t.Errorf("GetLen() = %d, want %d", got, tt.wantN)
+			}
+		})
+	}
+}
+
 func TestInodeFileTypeMutualExclusion(t *testing.T) {
 	modes := []struct {
 		name string

--- a/ext4/inode_test.go
+++ b/ext4/inode_test.go
@@ -1,0 +1,126 @@
+package ext4
+
+import "testing"
+
+func TestInodeFileType(t *testing.T) {
+	tests := []struct {
+		name            string
+		mode            uint16
+		wantDir         bool
+		wantRegular     bool
+		wantSymlink     bool
+		wantSocket      bool
+		wantFifo        bool
+		wantCharDevice  bool
+		wantBlockDevice bool
+	}{
+		{
+			name:        "regular file (0100644)",
+			mode:        0100644,
+			wantRegular: true,
+		},
+		{
+			name:    "directory (040755)",
+			mode:    040755,
+			wantDir: true,
+		},
+		{
+			name:        "symlink (0120777)",
+			mode:        0120777,
+			wantSymlink: true,
+		},
+		{
+			name:       "socket (0140755)",
+			mode:       0140755,
+			wantSocket: true,
+		},
+		{
+			name:     "fifo (010644)",
+			mode:     010644,
+			wantFifo: true,
+		},
+		{
+			name:           "char device (020666)",
+			mode:           020666,
+			wantCharDevice: true,
+		},
+		{
+			name:            "block device (060660)",
+			mode:            060660,
+			wantBlockDevice: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inode := Inode{Mode: tt.mode}
+			if got := inode.IsDir(); got != tt.wantDir {
+				t.Errorf("IsDir() = %v, want %v (mode: %#o)", got, tt.wantDir, tt.mode)
+			}
+			if got := inode.IsRegular(); got != tt.wantRegular {
+				t.Errorf("IsRegular() = %v, want %v (mode: %#o)", got, tt.wantRegular, tt.mode)
+			}
+			if got := inode.IsSymlink(); got != tt.wantSymlink {
+				t.Errorf("IsSymlink() = %v, want %v (mode: %#o)", got, tt.wantSymlink, tt.mode)
+			}
+			if got := inode.IsSocket(); got != tt.wantSocket {
+				t.Errorf("IsSocket() = %v, want %v (mode: %#o)", got, tt.wantSocket, tt.mode)
+			}
+			if got := inode.IsFifo(); got != tt.wantFifo {
+				t.Errorf("IsFifo() = %v, want %v (mode: %#o)", got, tt.wantFifo, tt.mode)
+			}
+			if got := inode.IsCharDevice(); got != tt.wantCharDevice {
+				t.Errorf("IsCharDevice() = %v, want %v (mode: %#o)", got, tt.wantCharDevice, tt.mode)
+			}
+			if got := inode.IsBlockDevice(); got != tt.wantBlockDevice {
+				t.Errorf("IsBlockDevice() = %v, want %v (mode: %#o)", got, tt.wantBlockDevice, tt.mode)
+			}
+		})
+	}
+}
+
+func TestInodeFileTypeMutualExclusion(t *testing.T) {
+	modes := []struct {
+		name string
+		mode uint16
+	}{
+		{"regular", 0100644},
+		{"directory", 040755},
+		{"symlink", 0120777},
+		{"socket", 0140755},
+		{"fifo", 010644},
+		{"char device", 020666},
+		{"block device", 060660},
+	}
+
+	for _, m := range modes {
+		t.Run(m.name, func(t *testing.T) {
+			inode := Inode{Mode: m.mode}
+			count := 0
+			if inode.IsDir() {
+				count++
+			}
+			if inode.IsRegular() {
+				count++
+			}
+			if inode.IsSymlink() {
+				count++
+			}
+			if inode.IsSocket() {
+				count++
+			}
+			if inode.IsFifo() {
+				count++
+			}
+			if inode.IsCharDevice() {
+				count++
+			}
+			if inode.IsBlockDevice() {
+				count++
+			}
+			if count != 1 {
+				t.Errorf("expected exactly 1 type match for mode %#o, got %d", m.mode, count)
+			}
+		})
+	}
+}

--- a/ext4/superblock.go
+++ b/ext4/superblock.go
@@ -215,10 +215,13 @@ func (sb *Superblock) GetGroupDescriptorTableCount() uint32 {
 }
 
 func (sb *Superblock) GetGroupDescriptorCount() uint32 {
+	ngroups := int64(sb.GetGroupDescriptorTableCount())
+	var descSize int64 = 32
 	if sb.FeatureInCompat64bit() {
-		return (sb.GetGroupDescriptorTableCount() * 64 / 1024) + 1
+		descSize = 64
 	}
-	return (sb.GetGroupDescriptorTableCount() * 32 / 1024) + 1
+	blockSize := sb.GetBlockSize()
+	return uint32((ngroups*descSize + blockSize - 1) / blockSize)
 }
 
 func (sb *Superblock) GetBlockSize() int64 {

--- a/ext4/superblock.go
+++ b/ext4/superblock.go
@@ -210,7 +210,8 @@ func (sb *Superblock) GetBlockCount() int64 {
 }
 
 func (sb *Superblock) GetGroupDescriptorTableCount() uint32 {
-	return (sb.BlockCountHi<<32|sb.BlockCountLo)/sb.BlockPerGroup + 1
+	blockCount := sb.GetBlockCount() - int64(sb.FirstDataBlock)
+	return uint32((blockCount + int64(sb.BlockPerGroup) - 1) / int64(sb.BlockPerGroup))
 }
 
 func (sb *Superblock) GetGroupDescriptorCount() uint32 {

--- a/ext4/superblock_test.go
+++ b/ext4/superblock_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestGetGroupDescriptorTableCount(t *testing.T) {
 	tests := []struct {
-		name           string
-		blockCountLo   uint32
-		blockCountHi   uint32
-		blockPerGroup  uint32
-		firstDataBlock uint32
+		name            string
+		blockCountLo    uint32
+		blockCountHi    uint32
+		blockPerGroup   uint32
+		firstDataBlock  uint32
 		featureIncompat uint32 // set FEATURE_INCOMPAT_64BIT if needed
-		want           uint32
+		want            uint32
 	}{
 		{
 			name:          "128MB 4KB blocks: exactly 1 group",
@@ -52,7 +52,7 @@ func TestGetGroupDescriptorTableCount(t *testing.T) {
 		{
 			name:            "64bit mode: BlockCountHi contributes",
 			blockCountLo:    0,
-			blockCountHi:    1,        // total = 1<<32 = 4294967296 blocks
+			blockCountHi:    1, // total = 1<<32 = 4294967296 blocks
 			blockPerGroup:   32768,
 			featureIncompat: FEATURE_INCOMPAT_64BIT,
 			want:            131072, // 4294967296 / 32768
@@ -205,7 +205,7 @@ func TestGetGroupDescriptor_SeekOffset(t *testing.T) {
 	}{
 		{
 			name:           "4KB blocks: GDT at block 1 (byte 4096)",
-			logBlockSize:   2,      // 1024<<2 = 4096
+			logBlockSize:   2, // 1024<<2 = 4096
 			firstDataBlock: 0,
 			blockCountLo:   32768,
 			blockPerGroup:  32768,
@@ -214,7 +214,7 @@ func TestGetGroupDescriptor_SeekOffset(t *testing.T) {
 		},
 		{
 			name:           "1KB blocks: GDT at block 2 (byte 2048)",
-			logBlockSize:   0,      // 1024<<0 = 1024
+			logBlockSize:   0, // 1024<<0 = 1024
 			firstDataBlock: 1,
 			blockCountLo:   8193,
 			blockPerGroup:  8192,

--- a/ext4/superblock_test.go
+++ b/ext4/superblock_test.go
@@ -96,6 +96,85 @@ func TestGetGroupDescriptorTableCount_32bitIgnoresHi(t *testing.T) {
 	}
 }
 
+func TestGetGroupDescriptorCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		blockCountLo    uint32
+		blockPerGroup   uint32
+		logBlockSize    uint32
+		featureIncompat uint32
+		want            uint32
+	}{
+		{
+			name:          "4KB blocks, 1 group: 1 block",
+			blockCountLo:  32768,
+			blockPerGroup: 32768,
+			logBlockSize:  2, // 4096
+			want:          1, // 1*32=32 bytes, ceil(32/4096)=1
+		},
+		{
+			name:          "4KB blocks, 128 groups: fits in 1 block",
+			blockCountLo:  128 * 32768,
+			blockPerGroup: 32768,
+			logBlockSize:  2,
+			want:          1, // 128*32=4096 bytes, ceil(4096/4096)=1
+		},
+		{
+			name:          "4KB blocks, 129 groups: needs 2 blocks",
+			blockCountLo:  129 * 32768,
+			blockPerGroup: 32768,
+			logBlockSize:  2,
+			want:          2, // 129*32=4128, ceil(4128/4096)=2
+		},
+		{
+			name:          "1KB blocks, 32 groups: fits in 1 block",
+			blockCountLo:  32 * 8192,
+			blockPerGroup: 8192,
+			logBlockSize:  0, // 1024
+			want:          1, // 32*32=1024, ceil(1024/1024)=1
+		},
+		{
+			name:          "1KB blocks, 33 groups: needs 2 blocks",
+			blockCountLo:  33 * 8192,
+			blockPerGroup: 8192,
+			logBlockSize:  0,
+			want:          2, // 33*32=1056, ceil(1056/1024)=2
+		},
+		{
+			name:            "64bit mode: 64-byte descriptors",
+			blockCountLo:    64 * 32768,
+			blockPerGroup:   32768,
+			logBlockSize:    2,
+			featureIncompat: FEATURE_INCOMPAT_64BIT,
+			want:            1, // 64*64=4096, ceil(4096/4096)=1
+		},
+		{
+			name:            "64bit mode: 65 groups needs 2 blocks",
+			blockCountLo:    65 * 32768,
+			blockPerGroup:   32768,
+			logBlockSize:    2,
+			featureIncompat: FEATURE_INCOMPAT_64BIT,
+			want:            2, // 65*64=4160, ceil(4160/4096)=2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &Superblock{
+				BlockCountLo:    tt.blockCountLo,
+				BlockPerGroup:   tt.blockPerGroup,
+				LogBlockSize:    tt.logBlockSize,
+				FeatureIncompat: tt.featureIncompat,
+			}
+			got := sb.GetGroupDescriptorCount()
+			if got != tt.want {
+				t.Errorf("GetGroupDescriptorCount() = %d, want %d (ngroups=%d)",
+					got, tt.want, sb.GetGroupDescriptorTableCount())
+			}
+		})
+	}
+}
+
 func TestGetGroupDescriptor_SeekOffset(t *testing.T) {
 	// buildImage places a single 32-byte GD at the given byte offset.
 	// The GD has InodeTableLo = marker so we can verify the correct offset

--- a/ext4/superblock_test.go
+++ b/ext4/superblock_test.go
@@ -1,6 +1,11 @@
 package ext4
 
-import "testing"
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
 
 func TestGetGroupDescriptorTableCount(t *testing.T) {
 	tests := []struct {
@@ -88,5 +93,79 @@ func TestGetGroupDescriptorTableCount_32bitIgnoresHi(t *testing.T) {
 	got := sb.GetGroupDescriptorTableCount()
 	if got != 1 {
 		t.Errorf("32-bit mode should ignore BlockCountHi, got %d, want 1", got)
+	}
+}
+
+func TestGetGroupDescriptor_SeekOffset(t *testing.T) {
+	// buildImage places a single 32-byte GD at the given byte offset.
+	// The GD has InodeTableLo = marker so we can verify the correct offset
+	// was read.
+	buildImage := func(t *testing.T, gdOffset int, marker uint32) *io.SectionReader {
+		t.Helper()
+		imageSize := gdOffset + SectorSize // enough room for one sector read
+		image := make([]byte, imageSize)
+
+		gd := GroupDescriptor32{InodeTableLo: marker}
+		buf := &bytes.Buffer{}
+		if err := binary.Write(buf, binary.LittleEndian, &gd); err != nil {
+			t.Fatal(err)
+		}
+		copy(image[gdOffset:], buf.Bytes())
+
+		return io.NewSectionReader(bytes.NewReader(image), 0, int64(imageSize))
+	}
+
+	tests := []struct {
+		name           string
+		logBlockSize   uint32 // 0=1KB, 2=4KB
+		firstDataBlock uint32
+		blockCountLo   uint32
+		blockPerGroup  uint32
+		expectedOffset int // byte offset where GDT should be read
+		marker         uint32
+	}{
+		{
+			name:           "4KB blocks: GDT at block 1 (byte 4096)",
+			logBlockSize:   2,      // 1024<<2 = 4096
+			firstDataBlock: 0,
+			blockCountLo:   32768,
+			blockPerGroup:  32768,
+			expectedOffset: 4096,
+			marker:         0xAAAA,
+		},
+		{
+			name:           "1KB blocks: GDT at block 2 (byte 2048)",
+			logBlockSize:   0,      // 1024<<0 = 1024
+			firstDataBlock: 1,
+			blockCountLo:   8193,
+			blockPerGroup:  8192,
+			expectedOffset: 2048,
+			marker:         0xBBBB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := buildImage(t, tt.expectedOffset, tt.marker)
+
+			sb := Superblock{
+				LogBlockSize:   tt.logBlockSize,
+				FirstDataBlock: tt.firstDataBlock,
+				BlockCountLo:   tt.blockCountLo,
+				BlockPerGroup:  tt.blockPerGroup,
+			}
+
+			gds, err := sb.getGroupDescriptor(*r)
+			if err != nil {
+				t.Fatalf("getGroupDescriptor() error: %v", err)
+			}
+			if len(gds) != 1 {
+				t.Fatalf("expected 1 GD, got %d", len(gds))
+			}
+			if gds[0].InodeTableLo != tt.marker {
+				t.Errorf("InodeTableLo = %#x, want %#x (GD read from wrong offset?)",
+					gds[0].InodeTableLo, tt.marker)
+			}
+		})
 	}
 }

--- a/ext4/superblock_test.go
+++ b/ext4/superblock_test.go
@@ -1,0 +1,92 @@
+package ext4
+
+import "testing"
+
+func TestGetGroupDescriptorTableCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		blockCountLo   uint32
+		blockCountHi   uint32
+		blockPerGroup  uint32
+		firstDataBlock uint32
+		featureIncompat uint32 // set FEATURE_INCOMPAT_64BIT if needed
+		want           uint32
+	}{
+		{
+			name:          "128MB 4KB blocks: exactly 1 group",
+			blockCountLo:  32768, // 128MB / 4KB
+			blockPerGroup: 32768,
+			want:          1,
+		},
+		{
+			name:          "128MB+1block 4KB blocks: 2 groups",
+			blockCountLo:  32769,
+			blockPerGroup: 32768,
+			want:          2,
+		},
+		{
+			name:          "256MB 4KB blocks: exactly 2 groups",
+			blockCountLo:  65536, // 256MB / 4KB
+			blockPerGroup: 32768,
+			want:          2,
+		},
+		{
+			name:           "1KB block size: firstDataBlock=1",
+			blockCountLo:   131072, // 128MB / 1KB
+			blockPerGroup:  8192,
+			firstDataBlock: 1,
+			want:           16, // (131072-1+8191)/8192 = 16
+		},
+		{
+			name:           "1KB block size: exact division",
+			blockCountLo:   8193, // 8192 usable blocks + 1 first_data_block
+			blockPerGroup:  8192,
+			firstDataBlock: 1,
+			want:           1,
+		},
+		{
+			name:            "64bit mode: BlockCountHi contributes",
+			blockCountLo:    0,
+			blockCountHi:    1,        // total = 1<<32 = 4294967296 blocks
+			blockPerGroup:   32768,
+			featureIncompat: FEATURE_INCOMPAT_64BIT,
+			want:            131072, // 4294967296 / 32768
+		},
+		{
+			name:          "small FS: fewer blocks than one group",
+			blockCountLo:  1024,
+			blockPerGroup: 32768,
+			want:          1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &Superblock{
+				BlockCountLo:    tt.blockCountLo,
+				BlockCountHi:    tt.blockCountHi,
+				BlockPerGroup:   tt.blockPerGroup,
+				FirstDataBlock:  tt.firstDataBlock,
+				FeatureIncompat: tt.featureIncompat,
+			}
+			got := sb.GetGroupDescriptorTableCount()
+			if got != tt.want {
+				t.Errorf("GetGroupDescriptorTableCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGroupDescriptorTableCount_32bitIgnoresHi(t *testing.T) {
+	// In 32-bit mode, BlockCountHi must NOT be used (even if non-zero)
+	sb := &Superblock{
+		BlockCountLo:    32768,
+		BlockCountHi:    9999, // garbage — should be ignored
+		BlockPerGroup:   32768,
+		FeatureIncompat: 0, // 32-bit mode
+	}
+	got := sb.GetGroupDescriptorTableCount()
+	if got != 1 {
+		t.Errorf("32-bit mode should ignore BlockCountHi, got %d, want 1", got)
+	}
+}


### PR DESCRIPTION
### Summary

This PR fixes multiple bugs and spec violations in the ext4 filesystem parser, adds HTree directory index support, and introduces comprehensive test coverage.

### Related Issues

- Fixes #15 — Error "failed to read inode: EOF" on small size filesystem
- Fixes #17 — Error reading directory entries; extents() using incorrect buffer size
- Fixes #18 — File that doesn't exist being returned by ReadDir()

### Bug Fixes

**Extent tree** ([Kernel docs: Extent Tree](https://docs.kernel.org/filesystems/ext4/dynamic.html#extent-tree), [OSDev: Extents](https://wiki.osdev.org/Ext4#Extents))

- Fix operator precedence bug in internal node physical address calculation (`LeafHigh<<32 + LeafLow*blockSize` → `(LeafHigh<<32 | LeafLow) * blockSize`)
  - Spec: `ei_leaf_hi` (upper 16 bits) and `ei_leaf_lo` (lower 32 bits) form a single physical block number
- Fix internal node read using `SectorSize` (512B) instead of actual block size, causing truncation on 4KB+ blocks (Fixes #17)
  - Spec: each node in the extent tree occupies one full filesystem block
- Add magic number (`0xF30A`) validation
  - Spec: `eh_magic` must be `0xF30A`
- Add depth limit check (max 5 per spec)
  - Spec: `EXT4_MAX_EXTENT_DEPTH = 5`
- Add parent-child depth consistency validation
  - Spec: child node depth must equal parent depth minus 1
- Add `entries > max` rejection
  - Spec: `eh_entries` must not exceed `eh_max`
- Sort extents once after collection instead of at every recursion level (perf)
- Use bitwise OR consistently for high/low bit concatenation (`offset()`)

**Inode** ([Kernel docs: Inode Table](https://docs.kernel.org/filesystems/ext4/dynamic.html#index-nodes), [OSDev: Inodes](https://wiki.osdev.org/Ext4#Inodes))

- Fix file type detection using proper `0xF000` bitmask (was using partial masks like `0xC000 != 0` which matched multiple types)
  - Spec: upper 4 bits of `i_mode` (`& 0xF000`) define file type exclusively
- Fix `FileInfo.Mode()` to correctly convert ext4 inode mode to Go `fs.FileMode` (was using direct cast `fs.FileMode(inode.Mode)` which has incompatible bit layout)
  - Spec: ext4 mode uses `0x4000` for directory, `0x8000` for regular file, etc.; Go `fs.FileMode` uses different bit positions
- Fix `getInode()` EOF on ext2/ext3 (InodeSize=128) by reading exact inode size with `ReadAt` instead of sector-aligned reads (Fixes #15)
  - Spec: `s_inode_size` defines on-disk inode size (128 bytes for ext2/ext3, 256 for ext4)
- Add `IsUninitialized()` and `GetLen()` for uninitialized extent handling (bit 15 flag)
  - Spec: bit 15 of `ee_len` marks extent as unwritten; reads should return zeros
- Add `IsFifo()`, `IsCharDevice()`, `IsBlockDevice()` methods
- Fix type assertion with ok check in `getInode` cache lookup

**Superblock / Group Descriptors** ([Kernel docs: Super Block](https://docs.kernel.org/filesystems/ext4/dynamic.html#the-super-block), [Kernel docs: Block Group Descriptors](https://docs.kernel.org/filesystems/ext4/dynamic.html#block-group-descriptors))

- Fix `GetGroupDescriptorTableCount()` 32-bit shift bug and ceiling division (Fixes #15)
  - Spec: group count = ceil((s_blocks_count - s_first_data_block) / s_blocks_per_group)
- Fix GDT seek offset for 1KB block sizes (`FirstDataBlock+1` instead of hardcoded block 1) (Fixes #15)
  - Spec: GDT starts at the block immediately after the superblock; for 1KB blocks, superblock is at block 1, so GDT starts at block 2
- Fix `GetGroupDescriptorCount()` to use actual block size

**Directory parsing** ([Kernel docs: Linear Directories](https://docs.kernel.org/filesystems/ext4/dynamic.html#linear-classic-directories))

- Fix: skip directory entries with `inode == 0` (deleted/unused entries) (Fixes #18)
  - Spec: "If an entry's inode is 0, it should be skipped"
- Fix: stop skipping `file_type=0` entries (valid on ext2 without `FILETYPE` feature)
  - Spec: `file_type` is only valid when `FEATURE_INCOMPAT_FILETYPE` is set
- Remove unreachable `0xDE` file_type check (checksum tail entries always have inode=0)
- Add `RecLen` boundary validation in `extractDirectoryEntries`

**File reading**

- Fix sparse file `Read()` double-write zeros bug on last block
- Handle uninitialized extents by returning zeros via sparse path
  - Spec: uninitialized extents (bit 15 set in `ee_len`) should read as all zeros

### New Features

**HTree directory index support** ([Kernel docs: Hash Tree Directories](https://docs.kernel.org/filesystems/ext4/dynamic.html#hash-tree-directories))

- Add `DxRootInfo`, `DxCountLimit` structs
  - Spec: `dx_root` contains dot/dotdot entries, `dx_root_info` (hash_version, indirect_levels), and `dx_countlimit` + `dx_entry` array
- Implement `listEntriesHTree()` for `INDEX_FL` directories
- Recursive internal node traversal via `collectLeafBlocks()`
  - Spec: internal nodes contain fake dirent + `dx_countlimit` + `dx_entry` array
- Support both extent-based and block-addressing directories
- Validate `IndirectLevels` (max 2, or 3 with `LARGEDIR`)
  - Spec: `FEATURE_INCOMPAT_LARGEDIR` raises max indirect levels from 2 to 3
- Validate `count <= limit` at root and internal nodes

**Block addressing** ([Kernel docs: Inode Table](https://docs.kernel.org/filesystems/ext4/dynamic.html#index-nodes), [OSDev: Block Addressing](https://wiki.osdev.org/Ext4#Block_Addressing))

- Integrate upstream PR #16 block addressing implementation
- Add `GetBlockAddresses()` with single/double/triple indirect block resolution
  - Spec: `i_block[0..11]` = direct, `i_block[12]` = single indirect, `i_block[13]` = double indirect, `i_block[14]` = triple indirect
- Add `fileFromBlock()` for non-extent file reading
- Handle sparse holes (null block pointers) correctly

**Other**
- Add `GetSuperBlock()` public method

### Spec References

- [Kernel docs: ext4 Data Structures and Algorithms](https://docs.kernel.org/filesystems/ext4/dynamic.html)
- [Kernel docs: ext4 Admin Guide](https://docs.kernel.org/admin-guide/ext4.html)
- [OSDev Wiki: Ext4](https://wiki.osdev.org/Ext4)

---

### 概要

このPRはext4ファイルシステムパーサーの複数のバグと仕様違反を修正し、HTreeディレクトリインデックスのサポートを追加し、包括的なテストカバレッジを導入します。

### バグ修正

**エクステントツリー** ([Kernel docs: Extent Tree](https://docs.kernel.org/filesystems/ext4/dynamic.html#extent-tree), [OSDev: Extents](https://wiki.osdev.org/Ext4#Extents))

- 内部ノードの物理アドレス計算における演算子優先度バグを修正（`LeafHigh<<32 + LeafLow*blockSize` → `(LeafHigh<<32 | LeafLow) * blockSize`）
  - 仕様: `ei_leaf_hi`（上位16ビット）と `ei_leaf_lo`（下位32ビット）が単一の物理ブロック番号を構成
- 内部ノード読み込みで `SectorSize`（512B）を使用していた問題を修正。4KB以上のブロックでエントリが切り詰められていた (Fixes #17)
  - 仕様: エクステントツリーの各ノードは1つの完全なファイルシステムブロックを占有
- マジックナンバー（`0xF30A`）検証を追加
  - 仕様: `eh_magic` は `0xF30A` でなければならない
- 深さ上限チェック（仕様上最大5）を追加
  - 仕様: `EXT4_MAX_EXTENT_DEPTH = 5`
- 親子ノード間の深さ整合性検証を追加
  - 仕様: 子ノードの深さは親の深さ-1でなければならない
- `entries > max` の検出を追加
  - 仕様: `eh_entries` は `eh_max` を超えてはならない
- ソートを再帰の各レベルではなく収集後に1回だけ実行するよう最適化
- high/low ビット結合にビットOR演算子を統一的に使用（`offset()`）

**Inode** ([Kernel docs: Inode Table](https://docs.kernel.org/filesystems/ext4/dynamic.html#index-nodes), [OSDev: Inodes](https://wiki.osdev.org/Ext4#Inodes))

- ファイルタイプ判定を正しい `0xF000` ビットマスクに修正（以前は `0xC000 != 0` のような部分マスクで複数タイプにマッチしていた）
  - 仕様: `i_mode` の上位4ビット（`& 0xF000`）がファイルタイプを排他的に定義
- `FileInfo.Mode()` が ext4 inode mode を Go の `fs.FileMode` に正しく変換するよう修正（以前は `fs.FileMode(inode.Mode)` の直接キャストで、ビットレイアウトが非互換だった）
  - 仕様: ext4 mode はディレクトリに `0x4000`、通常ファイルに `0x8000` 等を使用。Go の `fs.FileMode` は異なるビット位置を使用
- ext2/ext3（InodeSize=128）での `getInode()` EOF問題を修正。セクタアライメント読み取りの代わりに `ReadAt` で正確なサイズのみ読み取り (Fixes #15)
  - 仕様: `s_inode_size` がディスク上のinodeサイズを定義（ext2/ext3は128バイト、ext4は256バイト）
- 未初期化エクステント処理のための `IsUninitialized()` と `GetLen()` を追加（ビット15フラグ）
  - 仕様: `ee_len` のビット15が未書き込みエクステントを示す。読み取り時はゼロを返すべき
- `IsFifo()`, `IsCharDevice()`, `IsBlockDevice()` メソッドを追加
- `getInode` キャッシュ参照時の type assertion に ok チェックを追加

**スーパーブロック / グループディスクリプタ** ([Kernel docs: Super Block](https://docs.kernel.org/filesystems/ext4/dynamic.html#the-super-block), [Kernel docs: Block Group Descriptors](https://docs.kernel.org/filesystems/ext4/dynamic.html#block-group-descriptors))

- `GetGroupDescriptorTableCount()` の32ビットシフトバグと切り上げ除算を修正 (Fixes #15)
  - 仕様: グループ数 = ceil((s_blocks_count - s_first_data_block) / s_blocks_per_group)
- 1KBブロックサイズでのGDTシークオフセットを修正（ハードコードされたブロック1ではなく `FirstDataBlock+1`）(Fixes #15)
  - 仕様: GDTはスーパーブロック直後のブロックから開始。1KBブロックではスーパーブロックがブロック1にあるため、GDTはブロック2から開始
- `GetGroupDescriptorCount()` を実際のブロックサイズを使用するよう修正

**ディレクトリパース** ([Kernel docs: Linear Directories](https://docs.kernel.org/filesystems/ext4/dynamic.html#linear-classic-directories))

- `inode == 0` のディレクトリエントリ（削除済み/未使用）をスキップするよう修正 (Fixes #18)
  - 仕様: 「エントリのinodeが0の場合、スキップすべき」
- `file_type=0` のエントリのスキップを廃止（ext2の `FILETYPE` 機能なしでは有効な値）
  - 仕様: `file_type` は `FEATURE_INCOMPAT_FILETYPE` が設定されている場合のみ有効
- 到達不能な `0xDE` file_typeチェックを削除（チェックサムテールエントリは常にinode=0）
- `extractDirectoryEntries` に `RecLen` 境界バリデーションを追加

**ファイル読み取り**

- sparse ファイルの `Read()` で末尾ブロックにゼロを二重書き込みするバグを修正
- 未初期化エクステントを sparse パス経由でゼロ返却するよう対応
  - 仕様: 未初期化エクステント（`ee_len` のビット15がセット）は全てゼロとして読み取るべき

### 新機能

**HTreeディレクトリインデックスサポート** ([Kernel docs: Hash Tree Directories](https://docs.kernel.org/filesystems/ext4/dynamic.html#hash-tree-directories))

- `DxRootInfo`, `DxCountLimit` 構造体を追加
  - 仕様: `dx_root` はdot/dotdotエントリ、`dx_root_info`（hash_version, indirect_levels）、`dx_countlimit` + `dx_entry` 配列を含む
- `INDEX_FL` ディレクトリ向けの `listEntriesHTree()` を実装
- `collectLeafBlocks()` による内部ノードの再帰的走査
  - 仕様: 内部ノードはfake dirent + `dx_countlimit` + `dx_entry` 配列を含む
- エクステントベースとブロックアドレッシングの両方のディレクトリに対応
- `IndirectLevels` の検証（最大2、`LARGEDIR` 有効時は3）
  - 仕様: `FEATURE_INCOMPAT_LARGEDIR` で最大間接レベルが2から3に引き上げられる
- ルートおよび内部ノードでの `count <= limit` 検証

**ブロックアドレッシング** ([Kernel docs: Inode Table](https://docs.kernel.org/filesystems/ext4/dynamic.html#index-nodes), [OSDev: Block Addressing](https://wiki.osdev.org/Ext4#Block_Addressing))

- upstream PR #16 のブロックアドレッシング実装を統合
- 単一/二重/三重間接ブロック解決を含む `GetBlockAddresses()` を追加
  - 仕様: `i_block[0..11]` = 直接、`i_block[12]` = 単一間接、`i_block[13]` = 二重間接、`i_block[14]` = 三重間接
- non-extentファイル読み取り用の `fileFromBlock()` を追加
- sparse hole（nullブロックポインタ）の正しい処理

**その他**
- `GetSuperBlock()` パブリックメソッドを追加