### PR TITLE
fix: symlink resolution bugs in Open, ReadLink, Lstat

### DIFF
--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -626,7 +626,7 @@ func (ext4 *FileSystem) ReadLink(name string) (string, error) {
 }
 
 func (ext4 *FileSystem) Lstat(name string) (fs.FileInfo, error) {
-	return ext4.Stat(name)
+	return ext4.ReadDirInfo(name)
 }
 
 func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, error) {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -605,9 +605,9 @@ func (ext4 *FileSystem) ReadLink(name string) (string, error) {
 
 	// Depending on the target size, it is stored either in the inode block or the extents
 	targetSize := inode.GetSize()
-	if !inode.UsesExtents() {
-		path := string(inode.BlockOrExtents[:targetSize])
-		return filepath.Clean(path), nil
+	if !inode.UsesExtents() && targetSize <= int64(len(inode.BlockOrExtents)) {
+		target := string(inode.BlockOrExtents[:targetSize])
+		return filepath.Clean(target), nil
 	}
 
 	// For symlinks stored in extents, read the target using the File abstraction

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -540,7 +540,7 @@ func (ext4 *FileSystem) openWithDepth(name string, symlinkDepth int) (fs.File, e
 		return nil, ext4.wrapError(op, name, fs.ErrInvalid)
 	}
 
-	dirName, fileName := filepath.Split(name)
+	dirName, fileName := path.Split(name)
 	entries, err := ext4.ReadDir(dirName)
 	if err != nil {
 		return nil, ext4.wrapError(op, name, xerrors.Errorf("failed to read directory: %w", err))
@@ -555,20 +555,20 @@ func (ext4 *FileSystem) openWithDepth(name string, symlinkDepth int) (fs.File, e
 			return nil, xerrors.Errorf("unspecified error, entry is not dir entry %+v", entry)
 		}
 
+		fi := FileInfo{
+			name:  fileName,
+			ino:   dir.ino,
+			inode: dir.inode,
+		}
+
 		// Resolve symlinks
 		if dir.inode.IsSymlink() {
 			if symlinkDepth >= maxSymlinkDepth {
 				return nil, ext4.wrapError(op, name, xerrors.New("too many levels of symbolic links"))
 			}
-			fi := FileInfo{
-				name:  fileName,
-				ino:   dir.ino,
-				inode: dir.inode,
-				mode:  fs.FileMode(dir.inode.Mode),
-			}
 			link, err := ext4.readLink(fi, name)
 			if err != nil {
-				return nil, xerrors.Errorf("failed to read link: %w", err)
+				return nil, ext4.wrapError(op, name, xerrors.Errorf("failed to read link: %w", err))
 			}
 			if !path.IsAbs(link) {
 				link = path.Join(dirName, link)
@@ -576,11 +576,6 @@ func (ext4 *FileSystem) openWithDepth(name string, symlinkDepth int) (fs.File, e
 			return ext4.openWithDepth(link, symlinkDepth+1)
 		}
 
-		fi := FileInfo{
-			name:  fileName,
-			ino:   dir.ino,
-			inode: dir.inode,
-		}
 		var f *File
 		if fi.inode.UsesExtents() {
 			f, err = ext4.file(fi, name)
@@ -617,7 +612,7 @@ func (ext4 *FileSystem) readLink(fi FileInfo, name string) (string, error) {
 	targetSize := inode.GetSize()
 	if !inode.UsesExtents() && targetSize <= int64(len(inode.BlockOrExtents)) {
 		target := string(inode.BlockOrExtents[:targetSize])
-		return filepath.Clean(target), nil
+		return path.Clean(target), nil
 	}
 
 	// For symlinks stored in extents, read the target using the File abstraction
@@ -632,7 +627,7 @@ func (ext4 *FileSystem) readLink(fi FileInfo, name string) (string, error) {
 		return "", xerrors.Errorf("failed to read symlink target: %w", err)
 	}
 
-	return filepath.Clean(string(target)), nil
+	return path.Clean(string(target)), nil
 }
 
 func (ext4 *FileSystem) Lstat(name string) (fs.FileInfo, error) {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -630,7 +630,13 @@ func (ext4 *FileSystem) readLink(fi FileInfo, name string) (string, error) {
 }
 
 func (ext4 *FileSystem) Lstat(name string) (fs.FileInfo, error) {
-	return ext4.ReadDirInfo(name)
+	const op = "lstat"
+
+	info, err := ext4.ReadDirInfo(name)
+	if err != nil {
+		return nil, ext4.wrapError(op, name, err)
+	}
+	return info, nil
 }
 
 func (ext4 *FileSystem) fileFromBlock(fi FileInfo, filePath string) (*File, error) {

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -560,7 +560,13 @@ func (ext4 *FileSystem) openWithDepth(name string, symlinkDepth int) (fs.File, e
 			if symlinkDepth >= maxSymlinkDepth {
 				return nil, ext4.wrapError(op, name, xerrors.New("too many levels of symbolic links"))
 			}
-			link, err := ext4.ReadLink(name)
+			fi := FileInfo{
+				name:  fileName,
+				ino:   dir.ino,
+				inode: dir.inode,
+				mode:  fs.FileMode(dir.inode.Mode),
+			}
+			link, err := ext4.readLink(fi, name)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read link: %w", err)
 			}
@@ -598,10 +604,14 @@ func (ext4 *FileSystem) ReadLink(name string) (string, error) {
 	if !ok {
 		return "", xerrors.Errorf("unspecified error, entry is not file info %+v", fi)
 	}
-	inode := fi.inode
-	if !inode.IsSymlink() {
+	if !fi.inode.IsSymlink() {
 		return "", xerrors.Errorf("file is not symlink: %w", fs.ErrInvalid)
 	}
+	return ext4.readLink(fi, name)
+}
+
+func (ext4 *FileSystem) readLink(fi FileInfo, name string) (string, error) {
+	inode := fi.inode
 
 	// Depending on the target size, it is stored either in the inode block or the extents
 	targetSize := inode.GetSize()

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"path"
-	"path/filepath"
 	"strings"
 
 	"github.com/lunixbochs/struc"
@@ -103,7 +102,7 @@ func (ext4 *FileSystem) readDirEntry(name string) ([]fs.DirEntry, error) {
 	}
 
 	var currentIno int64
-	cleanedPath := filepath.ToSlash(filepath.Clean(name))
+	cleanedPath := path.Clean(name)
 	dirs := strings.Split(strings.Trim(cleanedPath, "/"), "/")
 	if len(dirs) == 1 && (dirs[0] == "." || dirs[0] == "") {
 		var dirEntries []fs.DirEntry

--- a/ext4/fs.go
+++ b/ext4/fs.go
@@ -523,7 +523,16 @@ func (ext4 *FileSystem) ReadDirInfo(name string) (fs.FileInfo, error) {
 	return nil, fs.ErrNotExist
 }
 
+// maxSymlinkDepth is the maximum number of symlink resolutions allowed
+// before returning an error, to prevent infinite loops.
+// This matches the Linux kernel's MAXSYMLINKS.
+const maxSymlinkDepth = 40
+
 func (ext4 *FileSystem) Open(name string) (fs.File, error) {
+	return ext4.openWithDepth(name, 0)
+}
+
+func (ext4 *FileSystem) openWithDepth(name string, symlinkDepth int) (fs.File, error) {
 	const op = "open"
 
 	name = strings.TrimPrefix(name, "/")
@@ -545,13 +554,20 @@ func (ext4 *FileSystem) Open(name string) (fs.File, error) {
 		if !ok {
 			return nil, xerrors.Errorf("unspecified error, entry is not dir entry %+v", entry)
 		}
+
 		// Resolve symlinks
 		if dir.inode.IsSymlink() {
-			link, err := ext4.ReadLink(dir.name)
+			if symlinkDepth >= maxSymlinkDepth {
+				return nil, ext4.wrapError(op, name, xerrors.New("too many levels of symbolic links"))
+			}
+			link, err := ext4.ReadLink(name)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to read link: %w", err)
 			}
-			return ext4.Open(link)
+			if !path.IsAbs(link) {
+				link = path.Join(dirName, link)
+			}
+			return ext4.openWithDepth(link, symlinkDepth+1)
 		}
 
 		fi := FileInfo{

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"io/fs"
 	"strings"
 	"testing"
 )
@@ -1419,5 +1420,257 @@ func TestListEntriesBlockAddressingReadAt(t *testing.T) {
 		if !names[expected] {
 			t.Errorf("expected %q in entries", expected)
 		}
+	}
+}
+
+// --- Symlink tests ---
+
+// setExtent writes a single extent (logical block → physical block) into an inode's BlockOrExtents field.
+func setExtent(inode *Inode, logicalBlock uint32, length uint16, physicalBlock uint32) {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, &ExtentHeader{
+		Magic: 0xF30A, Entries: 1, Max: 4, Depth: 0,
+	})
+	binary.Write(&buf, binary.LittleEndian, &Extent{
+		Block: logicalBlock, Len: length, StartHi: 0, StartLo: physicalBlock,
+	})
+	copy(inode.BlockOrExtents[:], buf.Bytes())
+}
+
+// writeInodeToImage serializes an inode and writes it to the correct offset
+// in the image, given the inode table starts at inodeTableBlock.
+func writeInodeToImage(image []byte, inodeNum int, inode *Inode, inodeTableBlock, blockSize, inodeSize int) {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.LittleEndian, inode)
+	offset := inodeTableBlock*blockSize + (inodeNum-1)*inodeSize
+	copy(image[offset:], buf.Bytes())
+}
+
+// buildSymlinkTestFS builds an in-memory ext4 filesystem with symlinks for testing.
+//
+// Layout:
+//
+//	Block 2: Inode table
+//	Block 4: Root directory entries
+//	Block 5: "subdir" directory entries
+//	Block 6: "hello.txt" content ("Hello, World!")
+//	Block 7: "subdir/target.txt" content ("Target content")
+//
+// Inodes:
+//
+//	2:  root directory
+//	10: "hello.txt" (regular file)
+//	11: "link.txt" (symlink → "hello.txt")
+//	12: "subdir" (directory)
+//	13: "subdir/target.txt" (regular file)
+//	14: "subdir/rel_link" (symlink → "../hello.txt")
+//	15: "loop1" (symlink → "loop2")
+//	16: "loop2" (symlink → "loop1")
+func buildSymlinkTestFS() *FileSystem {
+	const blockSize = 4096
+	const inodeSize = 256
+
+	totalSize := 8 * blockSize
+	image := make([]byte, totalSize)
+
+	// Root directory entries (block 4)
+	var rootDir []byte
+	rootDir = append(rootDir, buildDirEntry(10, "hello.txt", 1)...)
+	rootDir = append(rootDir, buildDirEntry(11, "link.txt", 7)...)
+	rootDir = append(rootDir, buildDirEntry(12, "subdir", 2)...)
+	rootDir = append(rootDir, buildDirEntry(15, "loop1", 7)...)
+	rootDir = append(rootDir, buildDirEntry(16, "loop2", 7)...)
+	copy(image[4*blockSize:], rootDir)
+
+	// Subdir directory entries (block 5)
+	var subdirDir []byte
+	subdirDir = append(subdirDir, buildDirEntry(13, "target.txt", 1)...)
+	subdirDir = append(subdirDir, buildDirEntry(14, "rel_link", 7)...)
+	copy(image[5*blockSize:], subdirDir)
+
+	// File content
+	copy(image[6*blockSize:], []byte("Hello, World!"))
+	copy(image[7*blockSize:], []byte("Target content"))
+
+	// Inode 2: root directory
+	rootInode := &Inode{Mode: 0x4000 | 0755, Flags: EXTENTS_FL, SizeLo: uint32(blockSize)}
+	setExtent(rootInode, 0, 1, 4)
+	writeInodeToImage(image, 2, rootInode, 2, blockSize, inodeSize)
+
+	// Inode 10: "hello.txt"
+	helloInode := &Inode{Mode: 0x8000 | 0644, Flags: EXTENTS_FL, SizeLo: 13}
+	setExtent(helloInode, 0, 1, 6)
+	writeInodeToImage(image, 10, helloInode, 2, blockSize, inodeSize)
+
+	// Inode 11: symlink "link.txt" → "hello.txt" (inline)
+	linkInode := &Inode{Mode: 0xA000 | 0777, SizeLo: 9}
+	copy(linkInode.BlockOrExtents[:], []byte("hello.txt"))
+	writeInodeToImage(image, 11, linkInode, 2, blockSize, inodeSize)
+
+	// Inode 12: "subdir"
+	subdirInode := &Inode{Mode: 0x4000 | 0755, Flags: EXTENTS_FL, SizeLo: uint32(blockSize)}
+	setExtent(subdirInode, 0, 1, 5)
+	writeInodeToImage(image, 12, subdirInode, 2, blockSize, inodeSize)
+
+	// Inode 13: "subdir/target.txt"
+	targetInode := &Inode{Mode: 0x8000 | 0644, Flags: EXTENTS_FL, SizeLo: 14}
+	setExtent(targetInode, 0, 1, 7)
+	writeInodeToImage(image, 13, targetInode, 2, blockSize, inodeSize)
+
+	// Inode 14: symlink "subdir/rel_link" → "../hello.txt" (inline)
+	relLinkInode := &Inode{Mode: 0xA000 | 0777, SizeLo: 12}
+	copy(relLinkInode.BlockOrExtents[:], []byte("../hello.txt"))
+	writeInodeToImage(image, 14, relLinkInode, 2, blockSize, inodeSize)
+
+	// Inode 15: symlink "loop1" → "loop2" (inline)
+	loop1Inode := &Inode{Mode: 0xA000 | 0777, SizeLo: 5}
+	copy(loop1Inode.BlockOrExtents[:], []byte("loop2"))
+	writeInodeToImage(image, 15, loop1Inode, 2, blockSize, inodeSize)
+
+	// Inode 16: symlink "loop2" → "loop1" (inline)
+	loop2Inode := &Inode{Mode: 0xA000 | 0777, SizeLo: 5}
+	copy(loop2Inode.BlockOrExtents[:], []byte("loop1"))
+	writeInodeToImage(image, 16, loop2Inode, 2, blockSize, inodeSize)
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	return &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+}
+
+func TestReadLinkInline(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	target, err := ext4fs.ReadLink("link.txt")
+	if err != nil {
+		t.Fatalf("ReadLink failed: %v", err)
+	}
+	if target != "hello.txt" {
+		t.Errorf("ReadLink = %q, want %q", target, "hello.txt")
+	}
+}
+
+func TestReadLinkNotSymlink(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	_, err := ext4fs.ReadLink("hello.txt")
+	if err == nil {
+		t.Fatal("ReadLink on regular file should fail")
+	}
+}
+
+func assertFileContent(t *testing.T, ext4fs *FileSystem, path, want string) {
+	t.Helper()
+	f, err := ext4fs.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%q) failed: %v", path, err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, 256)
+	n, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if got := string(buf[:n]); got != want {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+}
+
+func TestOpenFollowsSymlink(t *testing.T) {
+	assertFileContent(t, buildSymlinkTestFS(), "link.txt", "Hello, World!")
+}
+
+func TestOpenRelativeSymlinkInSubdir(t *testing.T) {
+	assertFileContent(t, buildSymlinkTestFS(), "subdir/rel_link", "Hello, World!")
+}
+
+func TestOpenCircularSymlink(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	_, err := ext4fs.Open("loop1")
+	if err == nil {
+		t.Fatal("Open on circular symlink should fail")
+	}
+	if !strings.Contains(err.Error(), "too many levels of symbolic links") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLstatReturnsSymlinkInfo(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	info, err := ext4fs.Lstat("link.txt")
+	if err != nil {
+		t.Fatalf("Lstat failed: %v", err)
+	}
+	if info.Mode()&fs.ModeSymlink == 0 {
+		t.Error("Lstat should return symlink mode, got non-symlink")
+	}
+	if info.Name() != "link.txt" {
+		t.Errorf("Lstat name = %q, want %q", info.Name(), "link.txt")
+	}
+	if info.Size() != 9 {
+		t.Errorf("Lstat size = %d, want 9 (length of target path)", info.Size())
+	}
+}
+
+func TestLstatRegularFile(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	info, err := ext4fs.Lstat("hello.txt")
+	if err != nil {
+		t.Fatalf("Lstat failed: %v", err)
+	}
+	if info.Mode()&fs.ModeSymlink != 0 {
+		t.Error("Lstat on regular file should not have symlink mode")
+	}
+	if info.Size() != 13 {
+		t.Errorf("Lstat size = %d, want 13", info.Size())
+	}
+}
+
+func TestReadLinkBoundsCheckInline(t *testing.T) {
+	// Symlink inode with targetSize > 60 but no EXTENTS_FL.
+	// Should fall through to the extent path and fail gracefully (not panic).
+	const blockSize = 4096
+	const inodeSize = 256
+
+	totalSize := 5 * blockSize
+	image := make([]byte, totalSize)
+
+	// Root directory at block 4 with one symlink entry
+	var rootDir []byte
+	rootDir = append(rootDir, buildDirEntry(10, "bad_link", 7)...)
+	copy(image[4*blockSize:], rootDir)
+
+	// Inode 2: root directory
+	rootInode := &Inode{Mode: 0x4000 | 0755, Flags: EXTENTS_FL, SizeLo: uint32(blockSize)}
+	setExtent(rootInode, 0, 1, 4)
+	writeInodeToImage(image, 2, rootInode, 2, blockSize, inodeSize)
+
+	// Inode 10: symlink with corrupt size (100 > 60), no EXTENTS_FL, no valid extent data
+	badInode := &Inode{Mode: 0xA000 | 0777, SizeLo: 100}
+	copy(badInode.BlockOrExtents[:], []byte("short"))
+	writeInodeToImage(image, 10, badInode, 2, blockSize, inodeSize)
+
+	sr := io.NewSectionReader(bytes.NewReader(image), 0, int64(totalSize))
+	ext4fs := &FileSystem{
+		r:  sr,
+		sb: Superblock{LogBlockSize: 2, InodePerGroup: 64, InodeSize: 256},
+		gds: []GroupDescriptor{
+			{GroupDescriptor32: GroupDescriptor32{InodeTableLo: 2}},
+		},
+		cache: &mockCache[string, any]{},
+	}
+
+	_, err := ext4fs.ReadLink("bad_link")
+	if err == nil {
+		t.Fatal("ReadLink with corrupt targetSize should fail")
 	}
 }

--- a/ext4/fs_test.go
+++ b/ext4/fs_test.go
@@ -3,6 +3,7 @@ package ext4
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"io/fs"
 	"strings"
@@ -1632,6 +1633,29 @@ func TestLstatRegularFile(t *testing.T) {
 	}
 	if info.Size() != 13 {
 		t.Errorf("Lstat size = %d, want 13", info.Size())
+	}
+}
+
+func TestLstatNotFoundReturnsPathError(t *testing.T) {
+	ext4fs := buildSymlinkTestFS()
+
+	_, err := ext4fs.Lstat("nonexistent.txt")
+	if err == nil {
+		t.Fatal("Lstat on missing file should fail")
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("error should wrap *fs.PathError, got %T: %v", err, err)
+	}
+	if pathErr.Op != "lstat" {
+		t.Errorf("Op = %q, want %q", pathErr.Op, "lstat")
+	}
+	if pathErr.Path != "nonexistent.txt" {
+		t.Errorf("Path = %q, want %q", pathErr.Path, "nonexistent.txt")
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("error should wrap fs.ErrNotExist, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix symlink support bugs introduced in PR #19, unify path handling, and add comprehensive tests.

### Bug fixes
- Fix `Open` passing only the basename to `ReadLink`, causing `ErrNotExist` for symlinks in subdirectories
- Resolve relative symlinks relative to the symlink's parent directory
- Prevent infinite recursion on circular symlinks (`maxSymlinkDepth = 40`, matching Linux `MAXSYMLINKS`)
- Make `Lstat` return the symlink's own `FileInfo` without following, matching the POSIX `lstat(2)` semantics. Previously `Lstat` delegated to `Stat`, which calls `Open` and follows symlinks — effectively behaving like `stat(2)`. Now it calls `ReadDirInfo` directly to return the symlink's own metadata.
- Add bounds check in `ReadLink` to prevent panic when inline `targetSize > 60`
- Fix `path` variable shadowing the `path` package in `ReadLink`

### Refactoring
- Extract `readLink` to avoid redundant inode re-lookup when called from `Open`
- Move `FileInfo` construction before the symlink check in `openWithDepth` to share across both paths

### Use `path` instead of `path/filepath` (Ref #12)
- Replace `filepath.ToSlash(filepath.Clean(...))` with `path.Clean()` in `readDirEntry`
- Use `path.Split` / `path.Clean` in `openWithDepth` / `readLink`
- ext4 is a POSIX filesystem and `io/fs.FS` requires `/`-separated paths — `path` is the correct package
- Remove `path/filepath` import from `fs.go`

### Tests
- Add 8 tests for symlink resolution:
  - `ReadLink` (inline target / non-symlink error)
  - `Open` (follow symlink / relative symlink in subdirectory)
  - Circular symlink detection (ELOOP)
  - `Lstat` (symlink info / regular file)
  - `ReadLink` bounds check for corrupt `targetSize`

### Test plan
- [x] `go test ./...` all pass
- [x] `go build ./...` success
- [x] `gofmt` formatted

---

## 概要

PR #19 で追加された symlink サポートのバグ修正、パスハンドリングの統一、テスト追加。

### バグ修正
- `Open` が `ReadLink` にベースネームのみを渡していたため、サブディレクトリ内の symlink で `ErrNotExist` になる問題を修正
- 相対シンボリックリンクを symlink の親ディレクトリ基準で解決するように修正
- 循環シンボリックリンクの無限再帰を防止（`maxSymlinkDepth = 40`、Linux `MAXSYMLINKS` 準拠）
- `Lstat` が symlink を追従せず symlink 自体の情報を返すように修正。POSIX `lstat(2)` と同様の動作に変更。修正前は `Stat` に委譲しており、`Stat` → `Open` → symlink 解決の流れで実質 `stat(2)` と同じ動作だった。修正後は `ReadDirInfo` を直接呼び、リンク自体のメタデータを返す。
- `ReadLink` のインラインパスで `targetSize > 60` 時のパニックを防止する境界チェック追加
- `ReadLink` 内の変数シャドウイングを修正

### リファクタリング
- `readLink` を抽出し、`Open` からの冗長な inode 再取得を排除
- `FileInfo` 構築を symlink チェック前に移動し両パスで共有

### `path/filepath` → `path` 統一 (Ref #12)
- `readDirEntry` の `filepath.ToSlash(filepath.Clean(...))` を `path.Clean()` に置換
- `openWithDepth` / `readLink` でも `path` パッケージを使用
- ext4 は POSIX ファイルシステムであり `io/fs.FS` の仕様も `/` 区切りのため `path` が正しい選択
- `fs.go` から `path/filepath` の import を削除

### テスト
- symlink 解決に関する 8 テストを追加（ReadLink / Open / 循環検出 / Lstat / 境界チェック）